### PR TITLE
simplify install and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,29 @@ JS client for YunoHost API
 **Please report issues here** (no registration needed):    
 https://dev.yunohost.org/projects/yunohost/issues
 
-
 ## Installation
 
-This client is a part of the YunoHost projet, and can not be installed
-directly. Please visit [YunoHost website](https://yunohost.org) for
-more information.
+This client is a part of the YunoHost projet, and can not be installed directly. Please visit [YunoHost website](https://yunohost.org) for more information.
 
 ## Contributing
 
 Feel free to improve the plugin and send us a pull request.
 
-We use gulp to compile Less files and minify the JavaScript.
-Assuming [nodejs](http://nodejs.org/) is installed, you can run a
-build with:
+We use `gulp` to compile Less files and minify the JavaScript. Assuming [nodejs](http://nodejs.org/) is installed, you can install dependencies and run a build with:
 
 ```sh
 cd src
-npm install
-npm install -g bower
-bower install
-npm install -g gulp
-gulp build
+npm i
+npm run build
 ```
-Alternatively you can pas the `--dev` option to gulp which improve building
-speed by bypassing compression tasks.
 
-On a YunoHost instance, the web admin files are located at 
-`/usr/share/yunohost/admin`.
+Alternatively you can run `npm run build-dev` which improves building speed by bypassing compression tasks.
+
+On a YunoHost instance, the web admin files are located at `/usr/share/yunohost/admin`.
 
 **Note:** The `.ms` - moustache - files are cached by the browser. You have to
 reach them manually some times you modify them. (e.g. go to
 https://example.com/yunohost/admin/views/domain/domain_list.ms)
-
-
 
 ## Dependencies
 

--- a/src/package.json
+++ b/src/package.json
@@ -5,6 +5,11 @@
     "type": "git",
     "url": "https://github.com/YunoHost/yunohost-admin"
   },
+  "scripts": {
+    "postinstall": "bower install",
+    "build": "gulp build",
+    "build-dev": "gulp build --dev"
+  },
   "author": "Yunohost",
   "license": "AGPL-3.0",
   "bugs": {


### PR DESCRIPTION
* `bower` and `gulp` are already part of `devDependencies` and we might as well use them instead of requiring to install them globally, this means the module is self contained and we can know for sure which versions of `bower` and `gulp` to use.
* added `postinstall` npm script which is invoked after dependencies have been installed, which we can use to call `bower install` to install the rest
* added `build` and `build-dev` npm scripts to call `gulp` which is already installed
