### PR TITLE
[fix] Ensure checkbox is not required for boolean fields

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -157,6 +157,7 @@
                 // Boolean fields
                 if (data.manifest.arguments.install[k].type == 'boolean') {
                     data.manifest.arguments.install[k].inputType = 'checkbox';
+                    data.manifest.arguments.install[k].required = '';
 
                     // Checked or not ?
                     if (typeof data.manifest.arguments.install[k].default !== 'undefined') {

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -157,7 +157,6 @@
                 // Boolean fields
                 if (data.manifest.arguments.install[k].type == 'boolean') {
                     data.manifest.arguments.install[k].inputType = 'checkbox';
-                    data.manifest.arguments.install[k].required = '';
 
                     // Checked or not ?
                     if (typeof data.manifest.arguments.install[k].default !== 'undefined') {
@@ -168,6 +167,9 @@
 
                     // 'default' is used as value, so we need to force it for checkboxes.
                     data.manifest.arguments.install[k].default = 1;
+
+                    // Checkbox should not be required to be unchecked
+                    data.manifest.arguments.install[k].required = '';
                 }
 
                 // 'password' type input.


### PR DESCRIPTION
This is *quite an urgent* bug since it prevent any boolean fields - defined in the app manifest - to be unchecked... Hopefully it only concerns a few applications - such as ownCloud, see the [concerned argument](https://github.com/YunoHost-Apps/owncloud_ynh/blob/master/manifest.json#L56-L62).