### PR TITLE
[enh] Working prototype for certificate management interface (#640)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -281,6 +281,7 @@
     "user_fullname": "Full name",
     "user_interface_link": "User interface",
     "user_mailbox_quota": "Mailbox quota",
+    "user_mailbox_use": "Mailbox used space",
     "user_new_forward": "newforward@myforeigndomain.org",
     "user_new_mail": "newmail@mydomain.org",
     "user_username": "Username",

--- a/src/views/user/user_info.ms
+++ b/src/views/user/user_info.ms
@@ -35,12 +35,13 @@
 
           <tr>
             <td><strong>{{t 'user_mailbox_quota'}}</strong></td>
-	    {{#if mailbox-quota.use}}
-            <td>{{mailbox-quota.use}} / {{mailbox-quota.limit}}</td>
-            {{else}}
-            <td>{{mailbox-quota}}</td>
-            {{/if}}
-          </tr
+            <td>{{mailbox-quota.limit}}</td>
+          </tr>
+
+          <tr>
+            <td><strong>{{t 'user_mailbox_use'}}</strong></td>
+            <td>{{mailbox-quota.use}}</td>
+          </tr>
 
           <tr>
             <td><strong>{{t 'user_emailaliases'}}</strong></td>


### PR DESCRIPTION
See https://dev.yunohost.org/issues/640

With the change made by https://github.com/YunoHost/yunohost/pull/186 the presentation of the mailbox quota was a bit misunderstandable.

**Before this PR on yunohost admin:**
Mailbox Quota 	5M / 500M -> ok

Mailbox Quota 	5M / No Quota -> here 5M is the mailbox used space

Mailbox Quota 	? / No Quota -> here 5M is the mailbox used space

**After this PR on yunohost admin:**
Mailbox Quota 	        500M
Mailbox used space 	5M

Mailbox Quota 	        No Quota
Mailbox used space 	5M

Mailbox Quota 	        No Quota
Mailbox used space 	?
