### PR TITLE
[fix] avoid empty whitespace for the first line of the logs display

### DIFF
--- a/src/views/service/service_log.ms
+++ b/src/views/service/service_log.ms
@@ -10,8 +10,7 @@
 <div class="container">
     {{#logs}}
         <h2>{{filename}}</h2>
-        <pre id="log" class="service-log">
-        {{filecontent}}
+        <pre id="log" class="service-log">{{filecontent}}
         </pre>
         <button data-paste-content="#log"><i class="fa-cloud-upload"></i> {{t 'upload'}}</button>
     {{/logs}}

--- a/src/views/service/service_log.ms
+++ b/src/views/service/service_log.ms
@@ -10,8 +10,7 @@
 <div class="container">
     {{#logs}}
         <h2>{{filename}}</h2>
-        <pre id="log" class="service-log">{{filecontent}}
-        </pre>
+        <pre id="log" class="service-log">{{filecontent}}</pre>
         <button data-paste-content="#log"><i class="fa-cloud-upload"></i> {{t 'upload'}}</button>
     {{/logs}}
 </div>


### PR DESCRIPTION
Hello,

Trivial fix. Right now, because of `<pre>` behavior, logs in the admin interfaces looks like that:

![2017-03-06-161432_748x166_scrot](https://cloud.githubusercontent.com/assets/41827/23615922/53170e5a-0288-11e7-8715-ad3016ab50d2.png)

Following this PR, they look like that:

![2017-03-06-161444_691x164_scrot](https://cloud.githubusercontent.com/assets/41827/23615937/5fdf6a7e-0288-11e7-8a3e-d3c56ce2c0d0.png)
