### PR TITLE
[enh] Manage appslists. #875

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -44,15 +44,24 @@
     app.get('#/apps/lists', function (c) {
         c.api('/appslists', function(data) {
             list = [];
+            var has_community_list = false;
             $.each(data, function(listname, listinfo) {
                 list.push({
                     'name': listname,
                     'url': listinfo['url'],
                     'lastUpdate': listinfo['lastUpdate']
                 });
+
+                // Check for community list
+                if (listname == 'community' || listinfo['url'] == 'https://app.yunohost.org/community.json') {
+                    has_community_list = true;
+                }
             });
 
-            c.view('app/app_appslists_list', {appslists: list});
+            c.view('app/app_appslists_list', {
+                appslists: list,
+                has_community_list: has_community_list
+            });
         }, 'GET');
     });
 

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -40,12 +40,85 @@
         });
     });
 
+    // List available apps lists
+    app.get('#/apps/lists', function (c) {
+        c.api('/appslists', function(data) {
+            list = [];
+            $.each(data, function(listname, listinfo) {
+                list.push({
+                    'name': listname,
+                    'url': listinfo['url'],
+                    'lastUpdate': listinfo['lastUpdate']
+                });
+            });
+
+            c.view('app/app_appslists_list', {appslists: list});
+        }, 'GET');
+    });
+
+    // Add a new apps list
+    app.post('#/apps/lists', function (c) {
+        list = {
+            'name' : c.params['appslist_name'],
+            'url' : c.params['appslist_url']
+        }
+
+        c.api('/appslists', function(data) {
+            store.clear('slide');
+            c.redirect('#/apps/lists/' + list.name);
+        }, 'PUT', list);
+    });
+
+    // Show appslist info and operations
+    app.get('#/apps/lists/:appslist', function (c) {
+        c.api('/appslists', function(data) {
+            if (typeof data[c.params['appslist']] !== 'undefined') {
+                list = {
+                    'name' : c.params['appslist'],
+                    'url': data[c.params['appslist']]['url'],
+                    'lastUpdate': data[c.params['appslist']]['lastUpdate'],
+                    'removable' : (c.params['appslist'] !== 'yunohost') ? true : false // Do not remove default apps list
+                };
+                c.view('app/app_appslists_info', {appslist: list});
+            }
+            else {
+                c.flash('warning', y18n.t('appslists_unknown_list', [c.params['appslist']]));
+                store.clear('slide');
+                c.redirect('#/apps/lists');
+            }
+        }, 'GET');
+    });
+
     // Refresh available apps list
-    app.get('#/apps/refresh', function (c) {
-        c.api('/appslists', function(data) { // http://api.yunohost.org/#!/app/app_fetchlist_put_5
+    app.get('#/apps/lists/refresh', function (c) {
+        c.api('/appslists', function(data) {
             // c.redirect(store.get('path'));
             c.redirect('#/apps/install');
         }, 'PUT');
+    });
+
+    // Refresh specific apps list
+    app.get('#/apps/lists/:appslist/refresh', function (c) {
+        c.api('/appslists', function(data) {
+            c.redirect('#/apps/lists');
+        }, 'PUT', {'name' : c.params['appslist']});
+    });
+
+    // Remove apps list
+    app.get('#/apps/lists/:appslist/remove', function (c) {
+        c.confirm(
+            y18n.t('appslist'),
+            y18n.t('appslist_confirm_remove', [c.params['app']]),
+            function() {
+                c.api('/appslists', function() {
+                    c.redirect('#/apps/lists');
+                }, 'DELETE', {'name' : c.params['appslist']});
+            },
+            function() {
+                store.clear('slide');
+                c.redirect('#/apps/lists/'+ c.params['appslist']);
+            }
+        );
     });
 
     // Get app information

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -108,7 +108,7 @@
     app.get('#/apps/lists/:appslist/remove', function (c) {
         c.confirm(
             y18n.t('appslist'),
-            y18n.t('appslist_confirm_remove', [c.params['app']]),
+            y18n.t('appslists_confirm_remove', [c.params['app']]),
             function() {
                 c.api('/appslists', function() {
                     c.redirect('#/apps/lists');

--- a/src/js/yunohost/main.js
+++ b/src/js/yunohost/main.js
@@ -25,6 +25,10 @@
         Handlebars.registerHelper('humanTime', function(time) {
             return Math.round(time) + 's';
         });
+        Handlebars.registerHelper('timestampToDate', function(timestamp) {
+            var date = new Date(timestamp * 1000);
+            return date.toLocaleString();
+        });
         Handlebars.registerHelper('bitRate', function(bytes, time) {
             var sizes = ['b', 'Kb', 'Mb', 'Gb', 'Tb'];
             if (time === 0) return 'n/a';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -340,6 +340,7 @@
     "appslists_community_list" : "Community applications list",
     "name" : "Name",
     "install_community_appslists_info" : "Community applications list allows you to install community maintained applications.<br />See the full list on <a href='https://yunohost.org/apps_in_progress'>yunohost.org/apps_in_progress</a>.",
+    "install_community_appslists_warning" : "Note that these applications packages are <strong>not</strong> offical and not maintained by the YunoHost team.<br />Installing these applications is at your own risks.",
     "install_custom_app_appslists_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
     "action": "Action",
     "add": "Add",
+    "remove": "Remove",
     "administration_password": "Administration password",
     "allowed_users": "Allowed users",
     "api_not_responding": "API is not responding",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -330,14 +330,16 @@
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",
     "revert_to_selfsigned_cert" : "Revert to a self-signed certificate",
     "appslists" : "Applications lists",
-    "appslists_add" : "Add applications list",
+    "appslists_custom" : "Custom applications list",
     "appslists_manage" : "Manage applications lists",
     "appslists_confirm_remove" : "Are you sure you want to remove this applications list?",
     "appslists_info_refresh_desc" : "Refresh applications status from this list.",
     "appslists_info_remove_desc" : "Applications from this list will not be available anymore.",
     "appslists_last_update" : "Last update",
     "appslists_unknown_list" : "Unknown apps list: %s",
+    "appslists_community_list" : "Community applications list",
     "name" : "Name",
+    "install_community_appslists_info" : "Community applications list allows you to install community maintained applications.<br />See the full list on <a href='https://yunohost.org/apps_in_progress'>yunohost.org/apps_in_progress</a>.",
     "install_custom_app_appslists_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -332,12 +332,12 @@
     "appslists" : "Applications lists",
     "appslists_add" : "Add applications list",
     "appslists_manage" : "Manage applications lists",
-    "appslist_confirm_remove" : "Are you sure you want to remove this applications list?",
+    "appslists_confirm_remove" : "Are you sure you want to remove this applications list?",
     "appslists_info_refresh_desc" : "Refresh applications status from this list.",
     "appslists_info_remove_desc" : "Applications from this list will not be available anymore.",
-    "appslist_last_update" : "Last update",
+    "appslists_last_update" : "Last update",
     "appslists_unknown_list" : "Unknown apps list: %s",
     "name" : "Name",
-    "install_custom_app_appslist_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
+    "install_custom_app_appslists_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -330,6 +330,7 @@
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",
     "revert_to_selfsigned_cert" : "Revert to a self-signed certificate",
     "appslists" : "Applications lists",
+    "appslists_no_lists" : "No applications lists",
     "appslists_custom" : "Custom applications list",
     "appslists_manage" : "Manage applications lists",
     "appslists_confirm_remove" : "Are you sure you want to remove this applications list?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -337,6 +337,7 @@
     "appslists_info_remove_desc" : "Applications from this list will not be available anymore.",
     "appslist_last_update" : "Last update",
     "appslists_unknown_list" : "Unknown apps list: %s",
-    "name" : "Name"
+    "name" : "Name",
+    "install_custom_app_appslist_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -328,6 +328,15 @@
     "regenerate_selfsigned_cert_message" : "If you want, you can regenerate the self-signed certificate.",
     "regenerate_selfsigned_cert" : "Regenerate self-signed certificate",
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",
-    "revert_to_selfsigned_cert" : "Revert to a self-signed certificate"
+    "revert_to_selfsigned_cert" : "Revert to a self-signed certificate",
+    "appslists" : "Applications lists",
+    "appslists_add" : "Add applications list",
+    "appslists_manage" : "Manage applications lists",
+    "appslist_confirm_remove" : "Are you sure you want to remove this applications list?",
+    "appslists_info_refresh_desc" : "Refresh applications status from this list.",
+    "appslists_info_remove_desc" : "Applications from this list will not be available anymore.",
+    "appslist_last_update" : "Last update",
+    "appslists_unknown_list" : "Unknown apps list: %s",
+    "name" : "Name"
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -340,7 +340,7 @@
     "appslists_community_list" : "Community applications list",
     "name" : "Name",
     "install_community_appslists_info" : "Community applications list allows you to install community maintained applications.<br />See the full list on <a href='https://yunohost.org/apps_in_progress'>yunohost.org/apps_in_progress</a>.",
-    "install_community_appslists_warning" : "Note that these applications packages are <strong>not</strong> offical and not maintained by the YunoHost team.<br />Installing these applications is at your own risks.",
+    "install_community_appslists_warning" : "Note that these applications packages are <strong>not</strong> official and not maintained by the YunoHost team.<br />Installing these applications is at your own risk and could break your system.",
     "install_custom_app_appslists_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
 

--- a/src/views/app/app_appslists_info.ms
+++ b/src/views/app/app_appslists_info.ms
@@ -17,7 +17,7 @@
             <dd>{{appslist.name}}</dd>
             <dt>{{t 'url'}}</dt>
             <dd>{{appslist.url}}</dd>
-            <dt>{{t 'appslist_last_update'}}</dt>
+            <dt>{{t 'appslists_last_update'}}</dt>
             <dd>{{timestampToDate appslist.lastUpdate}}</dd>
         </dl>
     </div>

--- a/src/views/app/app_appslists_info.ms
+++ b/src/views/app/app_appslists_info.ms
@@ -1,0 +1,49 @@
+<div class="btn-breadcrumb">
+    <a href="#/" ><i class="fa-home"></i><span class="sr-only">{{t 'home'}}</span></a>
+    <a href="#/apps">{{t 'applications'}}</a>
+    <a href="#/apps/lists">{{t 'appslists'}}</a>
+    <a href="#/apps/lists/{{name}}">{{appslist.name}}</a>
+</div>
+
+<div class="separator"></div>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title"><span class="fa-fw fa-info-circle"></span> {{t 'infos'}}</h2>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal">
+            <dt>{{t 'name'}}</dt>
+            <dd>{{appslist.name}}</dd>
+            <dt>{{t 'url'}}</dt>
+            <dd>{{appslist.url}}</dd>
+            <dt>{{t 'appslist_last_update'}}</dt>
+            <dd>{{timestampToDate appslist.lastUpdate}}</dd>
+        </dl>
+    </div>
+</div>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title">
+            <span class="fa-fw fa-wrench"></span> {{t 'operations'}}
+        </h2>
+    </div>
+    <div class="panel-body">
+        <div class="container">
+            <p>{{t 'appslists_info_refresh_desc'}}</p>
+            <a href="#/apps/lists/{{appslist.name}}/refresh" class="btn btn-info slide">
+                <span class="fa-refresh"></span> {{t 'refresh_app_list'}}
+            </a>
+        </div>
+        {{#appslist.removable}}
+        <hr>
+        <div class="container">
+            <p>{{t 'appslists_info_remove_desc'}}</p>
+            <a href="#/apps/lists/{{appslist.name}}/remove" class="btn btn-danger slide back">
+                <span class="fa-trash-o"></span> {{t 'remove'}}
+            </a>
+        </div>
+        {{/appslist.removable}}
+    </div>
+</div>

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -39,7 +39,7 @@
             <input type="hidden" name="appslist_name" value="community" required />
             <input type="hidden" name="appslist_url" value="https://app.yunohost.org/community.json" required />
             <div class="form-group">
-                <div class="col-md-10 col-sm-12">
+                <div class="col-md-12 col-sm-12">
                     <p>{{t 'install_community_appslists_info'}}</p>
                     <p class="alert alert-warning">
                         <span class="fa-warning"></span> {{t 'install_community_appslists_warning'}}

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -1,0 +1,54 @@
+<div class="btn-breadcrumb">
+    <a href="#/" ><i class="fa-home"></i><span class="sr-only">{{t 'home'}}</span></a>
+    <a href="#/apps">{{t 'applications'}}</a>
+    <a href="#/apps/lists">{{t 'appslists'}}</a>
+</div>
+
+<div class="separator"></div>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title"><span class="fa-fw fa-list"></span> {{t 'appslists'}}</h2>
+    </div>
+
+    <div class="list-group">
+        {{#appslists}}
+        <a href="#/apps/lists/{{name}}" class="list-group-item">
+            <span class="fa-chevron-right pull-right"></span>
+            <h2 class="list-group-item-heading">
+                {{name}}
+            </h2>
+        </a>
+        {{/appslists}}
+    </div>
+</div>
+
+
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title"><span class="fa-fw fa-plus"></span> {{t 'appslists_add'}}</h2>
+    </div>
+    <div class="panel-body">
+        <form action="#/apps/lists" method="POST" class="form-horizontal">
+            <div class="form-group has-feedback">
+                <label for="appslist_name" class="col-md-2 col-sm-12 control-label">{{t 'name'}}</label>
+                <div class="col-md-10 col-sm-12">
+                    <input type="text" id="appslist_name" name="appslist_name" class="form-control" value="" required />
+                </div>
+            </div>
+            <div class="form-group has-feedback">
+                <label for="appslist_url" class="col-md-2 col-sm-12 control-label">{{t 'url'}}</label>
+                <div class="col-md-10 col-sm-12">
+                    <input type="url" id="appslist_url" name="appslist_url" class="form-control" value="" placeholder="https://app.yunohost.org/community.json" required />
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="text-center">
+                    <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">
+                </div>
+            </div>
+        </form>
+        </div>
+    </div>
+</div>

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -20,6 +20,12 @@
             </h2>
         </a>
         {{/appslists}}
+        {{^appslists}}
+        <p class="list-group-item text-warning">
+            <span class="fa-exclamation-triangle"></span>
+            {{t 'appslists_no_lists'}}
+        </p>
+        {{/appslists}}
     </div>
 </div>
 

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -35,7 +35,7 @@
             <div class="form-group">
                 <div class="col-md-10 col-sm-12">
                     <p>{{t 'install_community_appslists_info'}}</p>
-                    <p class="alert alert-warning">
+                    <p class="alert alert-danger">
                         <span class="fa-warning"></span> {{t 'install_community_appslists_warning'}}
                     </p>
                     <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -35,6 +35,9 @@
             <div class="form-group">
                 <div class="col-md-10 col-sm-12">
                     <p>{{t 'install_community_appslists_info'}}</p>
+                    <p class="alert alert-warning">
+                        <span class="fa-warning"></span> {{t 'install_community_appslists_warning'}}
+                    </p>
                     <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">
                 </div>
             </div>

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -36,8 +36,8 @@
     </div>
     <div class="panel-body">
         <form action="#/apps/lists" method="POST" class="form-horizontal">
-            <input type="hidden" id="appslist_name" name="appslist_name" value="community" required />
-            <input type="hidden" id="appslist_url" name="appslist_url" value="https://app.yunohost.org/community.json" required />
+            <input type="hidden" name="appslist_name" value="community" required />
+            <input type="hidden" name="appslist_url" value="https://app.yunohost.org/community.json" required />
             <div class="form-group">
                 <div class="col-md-10 col-sm-12">
                     <p>{{t 'install_community_appslists_info'}}</p>

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -35,7 +35,7 @@
             <div class="form-group">
                 <div class="col-md-10 col-sm-12">
                     <p>{{t 'install_community_appslists_info'}}</p>
-                    <p class="alert alert-danger">
+                    <p class="alert alert-warning">
                         <span class="fa-warning"></span> {{t 'install_community_appslists_warning'}}
                     </p>
                     <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">

--- a/src/views/app/app_appslists_list.ms
+++ b/src/views/app/app_appslists_list.ms
@@ -23,11 +23,29 @@
     </div>
 </div>
 
-
+{{^has_community_list}}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title"><span class="fa-fw fa-plus"></span> {{t 'appslists_community_list'}}</h2>
+    </div>
+    <div class="panel-body">
+        <form action="#/apps/lists" method="POST" class="form-horizontal">
+            <input type="hidden" id="appslist_name" name="appslist_name" value="community" required />
+            <input type="hidden" id="appslist_url" name="appslist_url" value="https://app.yunohost.org/community.json" required />
+            <div class="form-group">
+                <div class="col-md-10 col-sm-12">
+                    <p>{{t 'install_community_appslists_info'}}</p>
+                    <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{{/has_community_list}}
 
 <div class="panel panel-default">
     <div class="panel-heading">
-        <h2 class="panel-title"><span class="fa-fw fa-plus"></span> {{t 'appslists_add'}}</h2>
+        <h2 class="panel-title"><span class="fa-fw fa-plus"></span> {{t 'appslists_custom'}}</h2>
     </div>
     <div class="panel-body">
         <form action="#/apps/lists" method="POST" class="form-horizontal">
@@ -44,11 +62,10 @@
                 </div>
             </div>
             <div class="form-group">
-                <div class="text-center">
+                <div class="col-md-10 col-md-push-2 col-sm-12">
                     <input type="submit" class="btn btn-success slide" value="{{t 'add'}}">
                 </div>
             </div>
         </form>
-        </div>
     </div>
 </div>

--- a/src/views/app/app_list_install.ms
+++ b/src/views/app/app_list_install.ms
@@ -5,7 +5,10 @@
 </div>
 
 <div class="actions-group">
-    <a href="#/apps/refresh" class="btn btn-info">
+    <a href="#/apps/lists" class="btn btn-success">
+        <span class="fa-list"></span> {{t 'appslists_manage'}}
+    </a>
+    <a href="#/apps/lists/refresh" class="btn btn-info">
         <span class="fa-refresh"></span> {{t 'refresh_app_list'}}
     </a>
 </div>
@@ -27,8 +30,6 @@
         {{/official}}
     </a>
 {{/apps}}
-</div>
-
 </div>
 
 <div class="panel panel-default">

--- a/src/views/app/app_list_install.ms
+++ b/src/views/app/app_list_install.ms
@@ -45,7 +45,7 @@
             <p><span class="fa-lightbulb-o"></span>
             {{t 'install_custom_app_appslist_info'}}</p>
             <p>
-                <a href="#/apps/list" class="btn btn-info">{{t 'appslists_manage'}}</a>
+                <a href="#/apps/lists" class="btn btn-info">{{t 'appslists_manage'}}</a>
             </p>
         </div>
         <form action="#/apps/install/custom" method="POST" class="form-horizontal">

--- a/src/views/app/app_list_install.ms
+++ b/src/views/app/app_list_install.ms
@@ -43,7 +43,7 @@
         </p>
         <div class="alert alert-info">
             <p><span class="fa-lightbulb-o"></span>
-            {{t 'install_custom_app_appslist_info'}}</p>
+            {{t 'install_custom_app_appslists_info'}}</p>
             <p>
                 <a href="#/apps/lists" class="btn btn-info">{{t 'appslists_manage'}}</a>
             </p>

--- a/src/views/app/app_list_install.ms
+++ b/src/views/app/app_list_install.ms
@@ -41,6 +41,13 @@
             <span class="fa-warning"></span>
             {{t 'confirm_install_custom_app'}}
         </p>
+        <div class="alert alert-info">
+            <p><span class="fa-lightbulb-o"></span>
+            {{t 'install_custom_app_appslist_info'}}</p>
+            <p>
+                <a href="#/apps/list" class="btn btn-info">{{t 'appslists_manage'}}</a>
+            </p>
+        </div>
         <form action="#/apps/install/custom" method="POST" class="form-horizontal">
             <div class="form-group has-feedback">
                 <label for="url" class="col-sm-12">{{t 'url'}}</label>


### PR DESCRIPTION
Addresses https://dev/yunohost.org/issues/875

## Screenshots

1- "Manage apps lists" button on /app/install page : 
![](https://lut.im/3CJZZgvcRS/r41K2whDIYGeJwuw.png)

2- List of apps lists and form to add new list
![](https://lut.im/EaNzqWfonH/eV4Z3DleFBfAbPYw.png)

3- List info and actions (refresh, remove)
![](https://lut.im/RI2chxzQ4x/TQVmkubpCnAvx1wf.png)


## Ideas

- Maybe the "list info" step is unnecessary and the "refresh" and "remove" buttons could live on the big list page.	

## Todo

- [x] Wait for YunoHost/yunohost#160 to be merged
- [x] Add simple button to add known lists such as "community"
- [x] Link to appslist page in the custom app installation form