### PR TITLE
[fix] 'hooks' key is now 'system' in backup info

### DIFF
--- a/src/js/yunohost/controllers/backup.js
+++ b/src/js/yunohost/controllers/backup.js
@@ -133,7 +133,7 @@
             };
             data['other_storages']=[];
             data['name']=c.params['archive'];
-            data['hooks']=c.groupHooks(Object.keys(data['hooks']));
+            data['hooks']=c.groupHooks(Object.keys(data['system']));
             data['items']=(data['hooks']!={} || data['apps']!=[]);
             c.view('backup/backup_info', data);
         });


### PR DESCRIPTION
### Problem

The output of `yunohost backup info` was slightly changed (the 'hooks' key was renamed 'system' for semantic) but this wasn't propagated to the admin interface.

(Probably related issue : https://dev.yunohost.org/issues/949 )

### Solution

Straightforwardly change the key