### PR TITLE
[fix] Correctly handle error 500

### DIFF
--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -133,6 +133,13 @@
                                 c.redirect('#/login');
                             }
                         }
+                        // 500
+                        else if (xhr.status == 500) {
+                            error_log = JSON.parse(xhr.responseText);
+                            error_log.route = error_log.route.join(' ') + '\n';
+                            error_log.arguments = JSON.stringify(error_log.arguments);
+                            c.flash('fail', y18n.t('internal_exception', [error_log.route, error_log.arguments, error_log.traceback]));
+                        }
                         // 502 Bad gateway means API is down
                         else if (xhr.status == 502) {
                             c.flash('fail', y18n.t('api_not_responding'));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -159,6 +159,7 @@
     "installed_apps": "Installed apps",
     "installing": "Installing",
     "interface": "Interface",
+    "internal_exception": "<strong>Yunohost encountered an internal error :/</strong><br><emph>Really sorry about that.<br>You should look for help on <a href=\"https://forum.yunohost.org/\">the forum</a> or <a href=\"https://chat.yunohost.org/\">the chat</a> to fix the situation, or report the bug on <a href=\"https://dev.yunohost.org/projects/yunohost/issues\">the bugtracker</a>.</emph><br>The following information might be useful for the person helping you :<h3>Action</h3><pre>%s%s</pre><h3>Traceback</h3><pre>%s</pre>",
     "io": "I/O",
     "ipv4": "IPv4",
     "ipv6": "IPv6",
@@ -345,4 +346,3 @@
     "install_community_appslists_warning" : "Note that these applications packages are <strong>not</strong> official and not maintained by the YunoHost team.<br />Installing these applications is at your own risk and could break your system.",
     "install_custom_app_appslists_info" : "Note that you can use alternative applications lists to install some other apps maintained by the YunoHost community."
 }
-

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -159,7 +159,7 @@
     "installed_apps": "Installed apps",
     "installing": "Installing",
     "interface": "Interface",
-    "internal_exception": "<strong>Yunohost encountered an internal error :/</strong><br><emph>Really sorry about that.<br>You should look for help on <a href=\"https://forum.yunohost.org/\">the forum</a> or <a href=\"https://chat.yunohost.org/\">the chat</a> to fix the situation, or report the bug on <a href=\"https://dev.yunohost.org/projects/yunohost/issues\">the bugtracker</a>.</emph><br>The following information might be useful for the person helping you :<h3>Action</h3><pre>%s%s</pre><h3>Traceback</h3><pre>%s</pre>",
+    "internal_exception": "<strong>Yunohost encountered an internal error :/</strong><br><em>Really sorry about that.<br>You should look for help on <a href=\"https://forum.yunohost.org/\">the forum</a> or <a href=\"https://chat.yunohost.org/\">the chat</a> to fix the situation, or report the bug on <a href=\"https://dev.yunohost.org/projects/yunohost/issues\">the bugtracker</a>.</em><br>The following information might be useful for the person helping you :<h3>Action</h3><pre>%s%s</pre><h3>Traceback</h3><pre>%s</pre>",
     "io": "I/O",
     "ipv4": "IPv4",
     "ipv6": "IPv6",


### PR DESCRIPTION
### Problem

At the moment, when the python core crashes because of unhandled exception, or whatever kind of unexpected bug, the web admin shows an obscure "500 Internal Server Error" with basically no explanation about what's going on in the backend (in addition to breaking the CSS of the whole page, c.f. https://dev.yunohost.org/issues/941). Hence it's complicated for people to explain the issue and provide useful information to help debugging (the only way is to try to run the same operation in CLI).

Illustration : 

![](https://framapic.org/DxwuHimCUZgo/7opOMdMIPCkh.png)

### Solution

The moulinette actually didn't handle properly Exceptions from the python code. Now that https://github.com/YunoHost/moulinette/pull/142 handles it, we can display a nice message with proper explanation and details. (The only dirty thing is that I added a bunch of html code in the en.json)

Illustration : 

![](https://framapic.org/lCy9TjniGCxe/bnILHbrSsCah.png)

### How to test it

Fetch and checkout this PR + the moulinette PR. Then add a dummy exception in yunohost (for instance, I added a simple `raise Exception` at the beginning of `backup_list()`. Then try to trigger the exception from the admin. (You might need to restart `yunohost-api` each time you touch moulinette/yunohost)