### PR TITLE
[fix] Tell user that domain dns-conf shows a recommendation only

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,6 +89,7 @@
     "default": "Default",
     "delete": "Delete",
     "description": "Description",
+    "domain_dns_conf_is_just_a_recommendation": "This page shows you the *recommended* configuration. It does *not* configure the DNS for you. It is your responsability to configure your DNS zone in your DNS registrar according to this recommendation.",
     "diagnosis": "Diagnosis",
     "diagnosis_hide_private": "Show diagnostic information without private data",
     "diagnosis_view_private": "Show diagnostic information including private data",

--- a/src/views/domain/domain_dns.ms
+++ b/src/views/domain/domain_dns.ms
@@ -4,8 +4,11 @@
     <a href="#/domains/{{name}}">{{name}}</a>
     <a href="#/domains/{{name}}/dns">{{t 'dns'}}</a>
 </div>
-
 <div class="separator"></div>
+
+<div class="alert alert-warning">
+    <span class="fa-fw fa-warning"></span> {{t 'domain_dns_conf_is_just_a_recommendation' }}
+</div>
 
 <div class="panel panel-default">
   <div class="panel-heading">


### PR DESCRIPTION
### Problem

Users who go to the 'DNS conf' page sometimes think that this shows some sort of actual configuration. We should tell them explicitly that this is only the recommended configuration which should be configured in the registrar.

Related issue on redmine : https://dev.yunohost.org/issues/559

### Solution

For the CLI, display a warning (see [related PR](https://github.com/YunoHost/yunohost/pull/346)). For the webadmin, display a warning block.