### PR TITLE
[enh] Upgrade just one app

### DIFF
--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -95,6 +95,29 @@
             );
         }
     });
+    
+    // Upgrade a specific apps
+    app.get('#/upgrade/apps/:app', function (c) {
+        c.confirm(
+            y18n.t('tools'),
+            // confirm_update_apps and confirm_update_packages
+            y18n.t('confirm_update_specific_app'),
+            function(){
+                c.api('/upgrade/apps?app='+c.params['app'].toLowerCase(),
+                        function(data) {
+                            // 'log' is a reserved name, maybe in handlebars
+                            data.logs = data.log;
+                            c.view('upgrade/upgrade', data);
+                        }, 'PUT');
+
+            },
+            function(){
+                store.clear('slide');
+                c.redirect('#/update');
+            }
+        );
+    });
+
 
     // Download SSL Certificate Authority
     app.get('#/tools/ca', function (c) {

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -100,7 +100,7 @@
     app.get('#/upgrade/apps/:app', function (c) {
         c.confirm(
             y18n.t('tools'),
-            y18n.t('confirm_update_specific_app'),
+            y18n.t('confirm_update_specific_app', [c.params['app']]),
             function(){
                 c.api('/upgrade/apps?app='+c.params['app'].toLowerCase(),
                         function(data) {

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -100,7 +100,6 @@
     app.get('#/upgrade/apps/:app', function (c) {
         c.confirm(
             y18n.t('tools'),
-            // confirm_update_apps and confirm_update_packages
             y18n.t('confirm_update_specific_app'),
             function(){
                 c.api('/upgrade/apps?app='+c.params['app'].toLowerCase(),
@@ -109,7 +108,6 @@
                             data.logs = data.log;
                             c.view('upgrade/upgrade', data);
                         }, 'PUT');
-
             },
             function(){
                 store.clear('slide');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,7 @@
     "confirm_uninstall": "Are you sure you want to uninstall %s ?",
     "confirm_update_apps": "Are you sure you want to update all applications?",
     "confirm_update_packages": "Are you sure you want to update all packages?",
-    "confirm_update_specific_app": "Are you sure you want to update this application ?",
+    "confirm_update_specific_app": "Are you sure you want to update %s?",
     "confirm_upnp_enable": "Are you sure you want to enable UPnP?",
     "confirm_upnp_disable": "Are you sure you want to disable UPnP?",
     "connection": "Connection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,6 +76,7 @@
     "confirm_uninstall": "Are you sure you want to uninstall %s ?",
     "confirm_update_apps": "Are you sure you want to update all applications?",
     "confirm_update_packages": "Are you sure you want to update all packages?",
+    "confirm_update_specific_app": "Are you sure you want to update this application ?",
     "confirm_upnp_enable": "Are you sure you want to enable UPnP?",
     "confirm_upnp_disable": "Are you sure you want to disable UPnP?",
     "connection": "Connection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -256,6 +256,8 @@
     "system_update": "System update",
     "system_upgrade": "System upgrade",
     "system_upgrade_btn": "Upgrade",
+    "system_upgrade_all_applications_btn": "Upgrade all applications",
+    "system_upgrade_all_packages_btn": "Upgrade all packages",
     "tcp": "TCP",
     "time_since_update": "Time since update: ",
     "tools": "Tools",

--- a/src/views/update/update.ms
+++ b/src/views/update/update.ms
@@ -42,14 +42,10 @@
     {{#if apps}}
     <div class="list-group">
         {{#apps}}
-        <div class="list-group-item"><div class="row"><div class="col-md-12">
-            <div class="pull-left">
-                <h3 class="list-group-item-heading">{{label}} <small>{{id}}</small></h3>
-            </div>
-            <div class="pull-right">
-                <a href="#/upgrade/apps/{{id}}" class="btn btn-success">{{t 'system_upgrade_btn'}}</a>
-            </div>
-        </div></div></div>
+        <div class="list-group-item clearfix">
+            <a href="#/upgrade/apps/{{id}}" class="btn btn-success pull-right">{{t 'system_upgrade_btn'}}</a>
+            <h3 class="list-group-item-heading">{{label}} <small>{{id}}</small></h3>
+        </div>
         {{/apps}}
     </div>
     <div class="panel-footer">

--- a/src/views/update/update.ms
+++ b/src/views/update/update.ms
@@ -42,9 +42,14 @@
     {{#if apps}}
     <div class="list-group">
         {{#apps}}
-        <div class="list-group-item">
-            <h3 class="list-group-item-heading">{{label}} <small>{{id}}</small></h3>
-        </div>
+        <div class="list-group-item"><div class="row"><div class="col-md-12">
+            <div class="pull-left">
+                <h3 class="list-group-item-heading">{{label}} <small>{{id}}</small></h3>
+            </div>
+            <div class="pull-right">
+                <a href="#/upgrade/apps/{{id}}" class="btn btn-success">{{t 'system_upgrade_btn'}}</a>
+            </div>
+        </div></div></div>
         {{/apps}}
     </div>
     <div class="panel-footer">

--- a/src/views/update/update.ms
+++ b/src/views/update/update.ms
@@ -26,7 +26,7 @@
         {{/packages}}
     </div>
     <div class="panel-footer">
-        <a href="#/upgrade/packages" class="btn btn-success">{{t 'system_upgrade_btn'}}</a>
+        <a href="#/upgrade/packages" class="btn btn-success">{{t 'system_upgrade_all_packages_btn'}}</a>
     </div>
     {{else}}
     <div class="panel-body">
@@ -49,7 +49,7 @@
         {{/apps}}
     </div>
     <div class="panel-footer">
-        <a href="#/upgrade/apps" class="btn btn-success">{{t 'system_upgrade_btn'}}</a>
+        <a href="#/upgrade/apps" class="btn btn-success">{{t 'system_upgrade_all_applications_btn'}}</a>
     </div>
     {{else}}
     <div class="panel-body">


### PR DESCRIPTION
## Problem
Some times user could be suspicious against one app, and don't want to upgrade it

## Suggested solution
Add a button to update just an app in the Update view

## How to test
This PR is related to the yunohost-api PR https://github.com/YunoHost/yunohost/pull/359
You can test with by upgrading an app.

To be able to upgrade an app, you can change the update_time by editing your apps settings /etc/yunohost/apps/APP/settings.yml

## PR Status
Opinion needed 

## Validation

- [x] **Principle agreement** 2/2 : opi, Aleks
- [x] **Quick review** 1/1 : Aleks
- [x] **Simple test** 1/1 : opi
- [x] **Deep review** 1/1: opi
