### PR TITLE
[enh] display warning and instruction to fix meltdown vulnerability

### DIFF
--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -71,8 +71,9 @@
                 c.flash('fail', y18n.t('error_retrieve_feed', [securityFeed]));
             });
 
-            c.api("/meltdown-spectre-check", function(data) {
-                if (!data.safe) {
+            c.api("/diagnosis", function(data) {
+                console.log(data);
+                if (data.security["spectre-meltdown"]) {
                     c.flash('danger', y18n.t('meltdown_spectre'));
                 }
             });

--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -71,6 +71,12 @@
                 c.flash('fail', y18n.t('error_retrieve_feed', [securityFeed]));
             });
 
+            c.api("/meltdown-spectre-check", function(data) {
+                if (!data.safe) {
+                    c.flash('danger', y18n.t('meltdown_spectre'));
+                }
+            });
+
             c.view('home');
         });
     });

--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -73,8 +73,8 @@
 
             c.api("/diagnosis", function(data) {
                 console.log(data);
-                if (data.security["spectre-meltdown"]) {
-                    c.flash('danger', y18n.t('meltdown_spectre'));
+                if (data.security["CVE-2017-5754"].vulnerable) {
+                    c.flash('danger', y18n.t('meltdown'));
                 }
             });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -343,7 +343,7 @@
     "install_letsencrypt_cert" : "Install a Let's Encrypt certificate",
     "manually_renew_letsencrypt_message" : "Certificate will be automatically renewed during the last 15 days of validity. You can manually renew it if you want to. (Not recommended).",
     "manually_renew_letsencrypt" : "Manually renew now",
-    "meltdown_spectre" : "You are vulnerable to the <a target=\"_blank\" href=\"https://meltdownattack.com/\">spectre and meltdown</a> critical security vulnerabilities. To apply the security patchs, you need to <a href=\"#/update\">update your system</a> then <a href=\"#/tools/reboot\">reboot it</a> to load the new linux kernel.",
+    "meltdown" : "You are vulnerable to the <a target=\"_blank\" href=\"https://meltdownattack.com/\">meltdown</a> critical security vulnerability. To fix that, you need to <a href=\"#/update\">update your system</a> then <a href=\"#/tools/reboot\">reboot it</a> to load the new linux kernel.",
     "regenerate_selfsigned_cert_message" : "If you want, you can regenerate the self-signed certificate.",
     "regenerate_selfsigned_cert" : "Regenerate self-signed certificate",
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -343,6 +343,7 @@
     "install_letsencrypt_cert" : "Install a Let's Encrypt certificate",
     "manually_renew_letsencrypt_message" : "Certificate will be automatically renewed during the last 15 days of validity. You can manually renew it if you want to. (Not recommended).",
     "manually_renew_letsencrypt" : "Manually renew now",
+    "meltdown_spectre" : "You are vulnerable to the <a target=\"_blank\" href=\"https://meltdownattack.com/\">spectre and meltdown</a> critical security vulnerabilities. To fix that, you need to <a href=\"#/update\">update your system</a> then <a href=\"#/tools/reboot\">reboot it</a> to load the new linux kernel.",
     "regenerate_selfsigned_cert_message" : "If you want, you can regenerate the self-signed certificate.",
     "regenerate_selfsigned_cert" : "Regenerate self-signed certificate",
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -343,7 +343,7 @@
     "install_letsencrypt_cert" : "Install a Let's Encrypt certificate",
     "manually_renew_letsencrypt_message" : "Certificate will be automatically renewed during the last 15 days of validity. You can manually renew it if you want to. (Not recommended).",
     "manually_renew_letsencrypt" : "Manually renew now",
-    "meltdown_spectre" : "You are vulnerable to the <a target=\"_blank\" href=\"https://meltdownattack.com/\">spectre and meltdown</a> critical security vulnerabilities. To fix that, you need to <a href=\"#/update\">update your system</a> then <a href=\"#/tools/reboot\">reboot it</a> to load the new linux kernel.",
+    "meltdown_spectre" : "You are vulnerable to the <a target=\"_blank\" href=\"https://meltdownattack.com/\">spectre and meltdown</a> critical security vulnerabilities. To apply the security patchs, you need to <a href=\"#/update\">update your system</a> then <a href=\"#/tools/reboot\">reboot it</a> to load the new linux kernel.",
     "regenerate_selfsigned_cert_message" : "If you want, you can regenerate the self-signed certificate.",
     "regenerate_selfsigned_cert" : "Regenerate self-signed certificate",
     "revert_to_selfsigned_cert_message" : "If you really want to, you can reinstall a self-signed certificate. (Not recommended)",


### PR DESCRIPTION
IMPORTANT: we'll need to rise the requirement yunohost version for the yunohost-admin .deb package to be sure that this patch will work.

Follow up of https://github.com/YunoHost/yunohost/pull/406 (which needs to be merged first).

Here is the displayed warning:

![2018-01-05-160520_1519x225_scrot](https://user-images.githubusercontent.com/41827/34614796-ee30a546-f232-11e7-91f5-0d0999b8762b.png)

Don't hesitate to modify the text if you have a better phrasing.
  