### PR TITLE
[enh] display stable/testing/unstable in footer

### DIFF
--- a/src/js/yunohost/events.js
+++ b/src/js/yunohost/events.js
@@ -9,7 +9,7 @@
      */
     app.bind('login', function(e, data) {
         this.api('/version', function(versions) {
-            $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost]));
+            $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
         });
     });
 

--- a/src/js/yunohost/main.js
+++ b/src/js/yunohost/main.js
@@ -77,7 +77,7 @@
             // Get YunoHost version
             if (sam.store.get('connected')) {
                 this.api('/version', function(versions) {
-                    $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost]));
+                    $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
                 });
             }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,7 +131,7 @@
     "everyone_has_access": "Everyone has access.",
     "filesystem": "Filesystem",
     "firewall": "Firewall",
-    "footer_version" : "Powered by <a href='https://yunohost.org'>YunoHost</a> %s.",
+    "footer_version" : "Powered by <a href='https://yunohost.org'>YunoHost</a> %s (%s).",
     "form_input_example" : "Example: %s",
     "free": "Free",
     "fs_type": "FS Type",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -296,7 +296,7 @@
     "wrong_password": "Mot de passe incorrect",
     "yes": "Oui",
     "form_input_example": "Exemple : %s",
-    "footer_version": "Propulsé par <a href='https://yunohost.org'>YunoHost</a> %s.",
+    "footer_version": "Propulsé par <a href='https://yunohost.org'>YunoHost</a> %s (%s).",
     "certificate_alert_not_valid": "Critique : le certificat actuel est invalide ! Le HTTPS ne fonctionnera pas du tout !",
     "certificate_alert_selfsigned": "Attention : le certification actuel est auto-signé. Les navigateurs afficheront une alerte effrayante aux nouveaux visiteurs !",
     "certificate_alert_letsencrypt_about_to_expire": "Le certificat actuel est sur le point d’expirer. Il doit être renouvelé automatiquement prochainement.",


### PR DESCRIPTION
To implement https://github.com/YunoHost/yunohost/pull/414  https://dev.yunohost.org/issues/718

Tested, work as expected.