### PR TITLE
Use the active/inactive status instead of running/exited/dead in service views

### DIFF
--- a/src/js/yunohost/controllers/services.js
+++ b/src/js/yunohost/controllers/services.js
@@ -48,9 +48,9 @@
             data2.service.name = c.params['service'];
             // Handlebars want booleans
             data2.service.is_loaded = (data.loaded=='enabled') ? true : false;
-            data2.service.is_running = (data.status=='running') ? true : false;
+            data2.service.is_running = (data.active=='active') ? true : false;
             // Translate status and loaded state
-            data2.service.status = y18n.t(data.status);
+            data2.service.active = y18n.t(data.active);
             data2.service.loaded = y18n.t(data.loaded);
             store.clear('slide');
             c.view('service/service_info', data2);

--- a/src/js/yunohost/controllers/services.js
+++ b/src/js/yunohost/controllers/services.js
@@ -18,7 +18,7 @@
                 v.name = k;
                 // Handlebars want booleans
                 v.is_loaded = (v.loaded=='enabled') ? true : false;
-                v.is_running = (v.status=='running') ? true : false;
+                v.is_running = (v.active=='active') ? true : false;
                 // Translate status and loaded state
                 v.status = y18n.t(v.status);
                 v.loaded = y18n.t(v.loaded);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,6 @@
 {
     "action": "Action",
+    "active": "Active",
     "add": "Add",
     "remove": "Remove",
     "administration_password": "Administration password",

--- a/src/views/service/service_info.ms
+++ b/src/views/service/service_info.ms
@@ -39,7 +39,7 @@
             <br>
             {{t 'service_status'}}
             <span class="text-{{#is_running}}success{{/is_running}}{{^is_running}}danger{{/is_running}}">
-            {{status}}
+            {{active}}
             </span>
             <br>
             {{t 'started_at'}}

--- a/src/views/service/service_list.ms
+++ b/src/views/service/service_list.ms
@@ -13,7 +13,7 @@
         <div class="list-group-item-text">
             {{t 'service_status'}}
             <span class="text-{{#is_running}}success{{/is_running}}{{^is_running}}danger{{/is_running}}">
-            {{status}}
+            {{active}}
             </span>
             <br>
             {{t 'started_at'}}


### PR DESCRIPTION
### Problem

Following the recent changes in the service list, a few users noticed/complained that some services are marked as 'exited' and in red. This is the case for yunohost-firewall and recently postfix (on stretch). But a status 'exited' is apparently okay and just relates to the way the service works (i.e. a daemon staying alive, or just commands being executed at start/stop, like the yunohost-firewall does). Therefore the 'exited' status is okay and in fact the service is active according to systemctl.

c.f. this screenshot : 

![capture du 2018-06-12 01-41-08](https://user-images.githubusercontent.com/4533074/41262602-1296c94e-6de2-11e8-862f-61767ad3959a.png)

### Solution

Use the `service.active` (=active/inactive) key instead of `service.status` (=running/exited/dead) in views

### PR status

Not tested because I was too lazy to setup my whole dev env é_è But I should test this at some point in the coming days