### PR TITLE
Backup is not experimental anymore

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,7 +47,6 @@
     "backup_content": "Backup content",
     "backup_create": "Create a backup",
     "backup_encryption_warning": "Don't forget this password, you'll need it if you want restore the archive",
-    "backup_experimental_warning": "Be aware that the backup feature is still experimental, and may not be fully reliable.",
     "backup_new": "New backup",
     "backup_optional_encryption": "Optional encryption",
     "backup_optional_password": "Optional password",

--- a/src/views/backup/backup.ms
+++ b/src/views/backup/backup.ms
@@ -11,10 +11,6 @@
 
 <div class="separator"></div>
 
-<div class="alert alert-warning">{{t 'backup_experimental_warning'}}</div>
-
-<div class="separator"></div>
-
 <div class="list-group">
 {{#each storages}}
     <a href="#/backup/{{id}}" class="list-group-item slide clearfix">

--- a/src/views/backup/backup_create.ms
+++ b/src/views/backup/backup_create.ms
@@ -7,10 +7,6 @@
 
 <div class="separator"></div>
 
-<div class="alert alert-warning">{{t 'backup_experimental_warning'}}</div>
-
-<div class="separator"></div>
-
 <form action="#/backup/{{storage.id}}" method="POST" class="form-horizontal">
     <div class="panel panel-default">
         <div class="panel-heading">

--- a/src/views/backup/backup_info.ms
+++ b/src/views/backup/backup_info.ms
@@ -7,10 +7,6 @@
 
 <div class="separator"></div>
 
-<div class="alert alert-warning">{{t 'backup_experimental_warning'}}</div>
-
-<div class="separator"></div>
-
 <div class="panel panel-default">
     <div class="panel-heading">
         <h2 class="panel-title"><span class="fa-fw fa-info-circle"></span> {{t 'infos'}}</h2>

--- a/src/views/backup/backup_list.ms
+++ b/src/views/backup/backup_list.ms
@@ -12,10 +12,6 @@
 
 <div class="separator"></div>
 
-<div class="alert alert-warning">{{t 'backup_experimental_warning'}}</div>
-
-<div class="separator"></div>
-
 <div class="list-group">
 {{#each archives}}
     <a href="#/backup/{{../storage.id}}/{{name}}" class="list-group-item slide clearfix">


### PR DESCRIPTION
### Problem

We still have this warning hanging in the webadmin saying that backup is an experimental feature. But it's not experimental anymore (at least not more experimental than YunoHost :P )

### Solution

Remove the warnings

### PR status

Yolo commited, not tested :| 