### PR TITLE
 Rename 'hooks' to system or system_parts in backup stuff

### DIFF
--- a/src/js/yunohost/controllers/backup.js
+++ b/src/js/yunohost/controllers/backup.js
@@ -62,7 +62,7 @@
 
 
     app.post('#/backup/:storage', function (c) {
-        var params = c.ungroupHooks(c.params['hooks'],c.params['apps']);
+        var params = c.ungroupHooks(c.params['system_parts'],c.params['apps']);
         c.api('/backup', function() {
             store.clear('slide');
             c.redirect('#/backup/'+ c.params['storage']);
@@ -75,7 +75,7 @@
             y18n.t('backup'),
             y18n.t('confirm_restore', [c.params['archive']]),
             $.proxy(function(c){
-                var params = c.ungroupHooks(c.params['hooks'],c.params['apps']);
+                var params = c.ungroupHooks(c.params['system_parts'],c.params['apps']);
                 params['force'] = '';
                 c.api('/backup/restore/'+c.params['archive'], function(data) {
                     store.clear('slide');
@@ -134,7 +134,7 @@
             };
             data.other_storages = [];
             data.name = c.params['archive'];
-            data.hooks = c.groupHooks(Object.keys(data['system']));
+            data.system_parts = c.groupHooks(Object.keys(data['system']));
             data.items = (data['hooks']!={} || data['apps']!=[]);
             c.view('backup/backup_info', data);
         });

--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -359,32 +359,31 @@
             return data;
         },
         
-        ungroupHooks: function(hooks,apps) {
+        ungroupHooks: function(system_parts,apps) {
             var data = {};
             data['apps'] = apps || [];
-            data['hooks'] = hooks || [];
+            data['system'] = system_parts || [];
             
-            if (data['hooks'].constructor !== Array) {
-                data['hooks'] = [data['hooks']];
+            if (data['system'].constructor !== Array) {
+                data['system'] = [data['system']];
             }
             if (data['apps'].constructor !== Array) {
                 data['apps'] = [data['apps']];
             }
 
-            if (data['hooks'].length == 0) {
-                data['ignore_hooks'] = '';
-            }
-            if (data['apps'].length == 0) {
-                data['ignore_apps'] = '';
-            }
-
             // Some hook value contains multiple hooks separated by commas
             var split_hooks = [];
-            $.each(data['hooks'], function(i, hook) {
+            $.each(data['system'], function(i, hook) {
                 split_hooks = split_hooks.concat(hook.split(','));
             });
-            data['hooks'] = split_hooks;
+            data['system'] = split_hooks;
 
+            if (data['system'].length == 0) {
+                delete data['system'];
+	    }
+            if (data['apps'].length == 0) {
+                delete data['apps'];
+	    }
             return data;
         },
 

--- a/src/views/backup/backup_create.ms
+++ b/src/views/backup/backup_create.ms
@@ -19,7 +19,7 @@
         <div class="list-group">
             {{#each hooks}}
                 <div class="list-group-item">
-                    <input type="checkbox" id="{{@key}}" name="hooks" value="{{value}}" checked class="nice-checkbox">
+                    <input type="checkbox" id="{{@key}}" name="system_parts" value="{{value}}" checked class="nice-checkbox">
                     <label for="{{@key}}" class="pull-right"><span class="sr-only">{{t 'check'}}</span></label>
                     <h2 class="list-group-item-heading">{{name}}</h2>
                     <p class="list-group-item-text">{{description}}</p>

--- a/src/views/backup/backup_info.ms
+++ b/src/views/backup/backup_info.ms
@@ -43,9 +43,9 @@
         {{/each}}
         {{#each apps}}
         <div class="list-group-item">
-            <input type="checkbox" id="{{id}}" name="apps" value="{{id}}" checked class="nice-checkbox">
-            <label for="{{id}}" class="pull-right"><span class="sr-only">{{t 'check'}}</span></label>
-            <h2 class="list-group-item-heading">{{name}} <small>{{id}}</small></h2>
+            <input type="checkbox" id="{{@key}}" name="apps" value="{{@key}}" checked class="nice-checkbox">
+            <label for="{{@key}}" class="pull-right"><span class="sr-only">{{t 'check'}}</span></label>
+            <h2 class="list-group-item-heading">{{name}} <small>{{@key}}</small></h2>
         </div>
         {{/each}}
         <div class="list-group-item clearfix">

--- a/src/views/backup/backup_info.ms
+++ b/src/views/backup/backup_info.ms
@@ -33,9 +33,9 @@
     </div>
     {{#if items}}
     <div class="list-group">
-        {{#each hooks}}
+        {{#each system_parts}}
         <div class="list-group-item">
-            <input type="checkbox" id="{{@key}}" name="hooks" value="{{value}}" checked class="nice-checkbox">
+            <input type="checkbox" id="{{@key}}" name="system_parts" value="{{value}}" checked class="nice-checkbox">
             <label for="{{@key}}" class="pull-right"><span class="sr-only">{{t 'check'}}</span></label>
             <h2 class="list-group-item-heading">{{name}}</h2>
             <p class="list-group-item-text">{{description}}</p>


### PR DESCRIPTION
This goes with https://github.com/YunoHost/yunohost/pull/490 that removes --hooks but which is still used by the admin. Therefore I replaced `hooks` with `system` where appropriate (or `system_parts` to keep the same semantic).

Doing this, I also noticed a bug due to the fact that the `id` key isn't present in apps info from `backup info` when displaying the corresponding view in the webadmin (fix: use `{{@key}}` instead)