### PR TITLE
Log 'xhr' variable in console when an unexpected error occur

### DIFF
--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -137,6 +137,7 @@
                             // Return HTTP error code at least
                             else {
                                 var errorMessage = xhr.status+' '+xhr.statusText;
+				console.log(xhr);
                                 c.flash('fail', y18n.t('error_server_unexpected', [errorMessage]));
                             }
 

--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -137,8 +137,8 @@
                             // Return HTTP error code at least
                             else {
                                 var errorMessage = xhr.status+' '+xhr.statusText;
-				console.log(xhr);
                                 c.flash('fail', y18n.t('error_server_unexpected', [errorMessage]));
+                                console.log(xhr);
                             }
 
                             // Remove loader if any


### PR DESCRIPTION
We regularly have 'error 0' errors on the webadmin which is a bit cryptic to debug. To help debugging, I propose to include a log of the 'xhr' variable in the console. That might help investigate the cause of the error (at least for us dev :s )