### PR TITLE
simply remove the 'installed' label

### DIFF
--- a/src/views/app/app_list_install.ms
+++ b/src/views/app/app_list_install.ms
@@ -21,7 +21,6 @@
         <span class="fa-chevron-right pull-right"></span>
         <h2 class="list-group-item-heading">
             {{name}} <small>{{id}}</small>
-            {{#installed}}<span class="badge badge-success" title="{{t 'status'}}">{{t 'installed'}}</span>{{/installed}}
         </h2>
         <p class="list-group-item-text">{{description}}</p>
         {{^official}}


### PR DESCRIPTION
Solve https://github.com/YunoHost/issues/issues/1170

Another label like 'install another' won't be more clear. Just removing the label seems more understandable.

Ljf idea to have a better UX on that point is to always display all apps in the install list but the uninstallable ones should be displayed greyed out. But is this worth it if a brand new app store comes soon ?

I haved just cut the label out.

