### PR TITLE
[enh] Display date in timezone of browser

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -144,10 +144,7 @@
 
             // Multi Instance settings
             data.manifest.multi_instance = data.manifest.multi_instance ? y18n.t('yes') : y18n.t('no');
-
-            // Installation date
-            var d = new Date(data.settings.install_time * 1000);
-            data.install_time = d.getDate() + '/' + (d.getMonth()+1) + '/' + d.getFullYear();
+            data.install_time = new Date(data.settings.install_time * 1000);
 
             c.view('app/app_info', data);
         });

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -88,9 +88,7 @@
                     'lastUpdate': data[c.params['appslist']]['lastUpdate'],
                     'removable' : (c.params['appslist'] !== 'yunohost') ? true : false // Do not remove default apps list
                 };
-                c.view('app/app_appslists_info', {
-                    appslist: list
-                });
+                c.view('app/app_appslists_info', {appslist: list});
             }
             else {
                 c.flash('warning', y18n.t('appslists_unknown_list', [c.params['appslist']]));

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -60,7 +60,8 @@
 
             c.view('app/app_appslists_list', {
                 appslists: list,
-                has_community_list: has_community_list
+                has_community_list: has_community_list,
+	            locale: y18n.locale
             });
         }, 'GET');
     });
@@ -88,7 +89,10 @@
                     'lastUpdate': data[c.params['appslist']]['lastUpdate'],
                     'removable' : (c.params['appslist'] !== 'yunohost') ? true : false // Do not remove default apps list
                 };
-                c.view('app/app_appslists_info', {appslist: list});
+                c.view('app/app_appslists_info', {
+                    appslist: list,
+	                locale: y18n.locale
+                });
             }
             else {
                 c.flash('warning', y18n.t('appslists_unknown_list', [c.params['appslist']]));

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -60,8 +60,7 @@
 
             c.view('app/app_appslists_list', {
                 appslists: list,
-                has_community_list: has_community_list,
-	            locale: y18n.locale
+                has_community_list: has_community_list
             });
         }, 'GET');
     });
@@ -90,8 +89,7 @@
                     'removable' : (c.params['appslist'] !== 'yunohost') ? true : false // Do not remove default apps list
                 };
                 c.view('app/app_appslists_info', {
-                    appslist: list,
-	                locale: y18n.locale
+                    appslist: list
                 });
             }
             else {

--- a/src/js/yunohost/controllers/backup.js
+++ b/src/js/yunohost/controllers/backup.js
@@ -136,6 +136,7 @@
             data.name = c.params['archive'];
             data.system_parts = c.groupHooks(Object.keys(data['system']));
             data.items = (data['hooks']!={} || data['apps']!=[]);
+	        data.locale = y18n.locale
             c.view('backup/backup_info', data);
         });
     });
@@ -153,6 +154,7 @@
                 data.archives2.unshift(info)
             });
             data.archives = data.archives2;
+	        data.locale = y18n.locale
             c.view('backup/backup_list', data);
         });
     });

--- a/src/js/yunohost/controllers/backup.js
+++ b/src/js/yunohost/controllers/backup.js
@@ -136,7 +136,7 @@
             data.name = c.params['archive'];
             data.system_parts = c.groupHooks(Object.keys(data['system']));
             data.items = (data['hooks']!={} || data['apps']!=[]);
-	        data.locale = y18n.locale
+            data.locale = y18n.locale
             c.view('backup/backup_info', data);
         });
     });
@@ -154,7 +154,7 @@
                 data.archives2.unshift(info)
             });
             data.archives = data.archives2;
-	        data.locale = y18n.locale
+            data.locale = y18n.locale
             c.view('backup/backup_list', data);
         });
     });

--- a/src/js/yunohost/controllers/services.js
+++ b/src/js/yunohost/controllers/services.js
@@ -23,7 +23,9 @@
                 v.status = y18n.t(v.status);
                 v.loaded = y18n.t(v.loaded);
                 if (v.active_at == 'unknown')
+                {
                     delete v.active_at;
+                }
                 data2.services.push(v);
             });
 
@@ -55,7 +57,9 @@
             data2.service.active = y18n.t(data.active);
             data2.service.loaded = y18n.t(data.loaded);
             if (data.active_at != 'unknown')
+            {
                 data2.service.active_at = data.active_at;
+            }
             store.clear('slide');
             c.view('service/service_info', data2);
         }, 'GET');

--- a/src/js/yunohost/controllers/services.js
+++ b/src/js/yunohost/controllers/services.js
@@ -22,6 +22,8 @@
                 // Translate status and loaded state
                 v.status = y18n.t(v.status);
                 v.loaded = y18n.t(v.loaded);
+                if (v.active_at == 'unknown')
+                    delete v.active_at;
                 data2.services.push(v);
             });
 
@@ -52,6 +54,8 @@
             // Translate status and loaded state
             data2.service.active = y18n.t(data.active);
             data2.service.loaded = y18n.t(data.loaded);
+            if (data.active_at != 'unknown')
+                data2.service.active_at = data.active_at;
             store.clear('slide');
             c.view('service/service_info', data2);
         }, 'GET');

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -121,7 +121,7 @@
 
             c.view('tools/tools_logs', {
                 "data": data,
-	            "locale": y18n.locale
+                "locale": y18n.locale
             });
         });
     });

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -121,7 +121,7 @@
 
             c.view('tools/tools_logs', {
                 "data": data,
-	        "locale": y18n.locale
+	            "locale": y18n.locale
             });
         });
     });
@@ -134,12 +134,6 @@
         
         c.api("/logs/display" + params, function(log) {
             if ('metadata' in log) {
-                if ('started_at' in log.metadata) {
-                    log.metadata.started_at = Date.parse(log.metadata.started_at)
-                }
-                if ('ended_at' in log.metadata) {
-                    log.metadata.ended_at = Date.parse(log.metadata.ended_at)
-                }
                 if (!'env' in log.metadata && 'args' in log.metadata) {
                     log.metadata.env = log.metadata.args
                 }

--- a/src/js/yunohost/main.js
+++ b/src/js/yunohost/main.js
@@ -26,10 +26,6 @@
         Handlebars.registerHelper('humanTime', function(time) {
             return Math.round(time) + 's';
         });
-        Handlebars.registerHelper('timestampToDate', function(timestamp) {
-            var date = new Date(timestamp * 1000);
-            return date.toLocaleString();
-        });
         Handlebars.registerHelper('bitRate', function(bytes, time) {
             var sizes = ['b', 'Kb', 'Mb', 'Gb', 'Tb'];
             if (time === 0) return 'n/a';

--- a/src/views/app/app_appslists_info.ms
+++ b/src/views/app/app_appslists_info.ms
@@ -18,7 +18,7 @@
             <dt>{{t 'url'}}</dt>
             <dd>{{appslist.url}}</dd>
             <dt>{{t 'appslists_last_update'}}</dt>
-            <dd>{{timestampToDate appslist.lastUpdate}}</dd>
+            <dd>{{formatTime appslist.lastUpdate day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>
         </dl>
     </div>
 </div>

--- a/src/views/app/app_info.ms
+++ b/src/views/app/app_info.ms
@@ -22,7 +22,7 @@
             <dt>{{t 'multi_instance'}}</dt>
             <dd>{{manifest.multi_instance}}</dd>
             <dt>{{t 'install_time'}}</dt>
-            <dd>{{install_time}}</dd>
+            <dd>{{formatTime install_time day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>
             <dt>{{t 'url'}}</dt>
             <dd><a href="https://{{settings.domain}}{{settings.path}}" target="_blank">https://{{settings.domain}}{{settings.path}}</a></dd>
         </dl>

--- a/src/views/backup/backup_info.ms
+++ b/src/views/backup/backup_info.ms
@@ -14,7 +14,7 @@
     <div class="panel-body">
         <dl class="dl-horizontal">
             <dt>{{t 'id'}}</dt><dd>{{ name }}</dd>
-            <dt>{{t 'created_at'}}</dt><dd>{{ created_at }}</dd>
+            <dt>{{t 'created_at'}}</dt><dd>{{formatTime created_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>
             <dt>{{t 'size'}}</dt><dd>{{ humanSize size}}</dd>
             <dt>{{t 'path'}}</dt><dd>{{ path }}</dd>
         </dl>

--- a/src/views/backup/backup_list.ms
+++ b/src/views/backup/backup_list.ms
@@ -12,11 +12,12 @@
 
 <div class="separator"></div>
 
+{{#intl locales=locale}}
 <div class="list-group">
 {{#each archives}}
-    <a href="#/backup/{{../storage.id}}/{{name}}" class="list-group-item slide clearfix">
+    <a href="#/backup/{{../storage.id}}/{{name}}" class="list-group-item slide clearfix" title='{{formatTime created_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}'>
         <span class="pull-right fa-chevron-right"></span>
-        <h2 class="list-group-item-heading">{{created_at}} <small>{{name}} ({{humanSize size}})</small></h2>
+        <h2 class="list-group-item-heading">{{formatRelative created_at}} <small>{{name}} ({{humanSize size}})</small></h2>
         <p class="list-group-item-text">{{path}}</p>
     </a>
 {{/each}}
@@ -28,6 +29,7 @@
 {{/archives}}
 
 </div>
+{{/intl}}
 
 <!--<div class="panel panel-default">
     <div class="panel-heading">

--- a/src/views/service/service_info.ms
+++ b/src/views/service/service_info.ms
@@ -43,7 +43,12 @@
             </span>
             <br>
             {{t 'started_at'}}
-            {{active_at.human}}
+            {{#active_at}}
+            {{formatTime . day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}
+            {{/active_at}}
+            {{^active_at}}
+            {{t 'unknown'}}
+            {{/active_at}}
         </div>
 
         <div class="pull-right">

--- a/src/views/service/service_list.ms
+++ b/src/views/service/service_list.ms
@@ -17,7 +17,12 @@
             </span>
             <br>
             {{t 'started_at'}}
-            {{active_at.human}}
+            {{#active_at}}
+            {{formatTime . day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}
+            {{/active_at}}
+            {{^active_at}}
+            {{t 'unknown'}}
+            {{/active_at}}
         </div>
     </a>
 {{/services}}


### PR DESCRIPTION
## The problem

The way to manage date was not everywhere the same, this PR try to harmonize the date management.
Current date management doesn't use timezone, so somehour could be wrong.

## Solution

Use formatTime everywhere to display date in the timezone of the browser.
Consider the API always returns a date containg timezone info. If not the date will be displayed as it with the browser timezone...

## Status
Ready
This PR is linked to 
https://github.com/YunoHost/yunohost/pull/552