### PR TITLE
Don't run initial checks each time home page is displayed

### DIFF
--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -3,6 +3,8 @@
     var app = Sammy.apps['#main'];
     var store = app.store;
 
+    var initial_checks_already_performed = false;
+
     /**
      * Home
      *
@@ -10,7 +12,11 @@
 
      // Home page
     app.get('#/', function (c) {
-        c.api('/users', function(data) {
+        if (initial_checks_already_performed)
+        {
+            c.view("home");
+        }
+        else c.api('/users', function(data) {
             // Warn admin if no users are created.
             if (typeof data.users !== 'undefined' && data.users.length === 0) {
                 c.flash('warning', y18n.t('warning_first_user'));
@@ -77,6 +83,7 @@
                 }
             });
 
+            initial_checks_already_performed = true;
             c.view('home');
         });
     });


### PR DESCRIPTION
### Problem

Currently, each time the home page is displayed, several "checks" are re-ran such as the existence of at least one user, fetching the security rss feed, and checking diagnosis for meltdown/spectre, and meanwhile the pacman is loading.

This is no big deal on fast servers, but it takes quite some times on slow hardware like ARM board. You easily end up having to wait ~5 seconds to be able to actually do anything.

### Solution

Perform checks only the first time home is shown.
Code isn't so pretty but meh can't do much without recoding everything using ES6

