### PR TITLE
[enh] Confirm when installing experimental or low quality apps

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -18,10 +18,10 @@
     });
 
     function levelToColor(level) {
-        if (level > 6) {
+        if (level >= 3) {
             return 'success';
         }
-        else if (level >= 2) {
+        else if (level >= 1) {
             return 'warning';
         }
         else if (isNaN(level)) {

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -41,13 +41,14 @@
     }
 
     function combineColors(stateColor, levelColor, installable) {
-        if (stateColor === "dangers" || levelColor === "danger") {
+        if (stateColor === "danger" || levelColor === "danger") {
             return 'danger';
         }
-        if (stateColor === "warnings" || levelColor === "warnings" || levelColor === "default") {
+        else if (stateColor === "warning" || levelColor === "warning" || levelColor === "default") {
             return 'warning';
         }
-        else {
+        else
+        {
             return 'success';
         }
     }

--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -492,11 +492,36 @@
     // App installation form
     app.get('#/apps/install/:app', function (c) {
         c.api('/apps?raw', function(data) { // http://api.yunohost.org/#!/app/app_list_get_8
-            c.appInstallForm(
-                c.params['app'],
-                data[c.params['app']].manifest,
-                c.params
-            );
+            var state_color = stateToColor(data[c.params['app']]['state']);
+            var level_color = levelToColor(parseInt(data[c.params['app']]['level']));
+            var is_safe_for_install_color = combineColors(state_color, level_color);
+
+            if ((is_safe_for_install_color === "warning") || (is_safe_for_install_color === "danger"))
+            {
+                c.confirm(
+                    y18n.t("applications"),
+                    y18n.t("confirm_install_app_"+is_safe_for_install_color),
+                    function(){
+                        c.appInstallForm(
+                            c.params['app'],
+                            data[c.params['app']].manifest,
+                            c.params
+                        );
+                    },
+                    function(){
+                        $('div.loader').remove();
+                        c.redirect('#/apps/install');
+                    }
+                );
+            }
+            else
+            {
+                c.appInstallForm(
+                    c.params['app'],
+                    data[c.params['app']].manifest,
+                    c.params
+                );
+            }
         });
     });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -77,6 +77,8 @@
     "confirm_firewall_close": "Are you sure you want to close port %s? (protocol: %s, connection: %s)",
     "confirm_install_custom_app": "Installing 3rd party applications may compromise the security of your system. Use at your own risk.",
     "confirm_install_domain_root": "You will not be able to install any other app on %s. Continue ?",
+    "confirm_install_app_warning": "Warning : this application may work but is not well-integrated in YunoHost. Some features such as single sign-on and backup/restore might not be available.",
+    "confirm_install_app_danger": "WARNING ! This application is still experimental and is likely to break your system ! You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",
     "confirm_migrations_skip": "Skipping migrations is not recommended. Are you sure you want to do that?",
     "confirm_postinstall": "You are about to launch the post-installation process on the domain %s. It may take a few minutes, *do not interrupt the operation*.",
     "confirm_restore": "Are you sure you want to restore %s ?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,7 +78,7 @@
     "confirm_install_custom_app": "WARNING ! Installing 3rd party applications may compromise the integrity and security of your system. You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",
     "confirm_install_domain_root": "You will not be able to install any other app on %s. Continue ?",
     "confirm_install_app_warning": "Warning : this application may work but is not well-integrated in YunoHost. Some features such as single sign-on and backup/restore might not be available.",
-    "confirm_install_app_danger": "WARNING ! This application is still experimental and is likely to break your system ! You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",
+    "confirm_install_app_danger": "WARNING ! This application is still experimental (if not explicitly not working) and it is likely to break your system ! You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",
     "confirm_migrations_skip": "Skipping migrations is not recommended. Are you sure you want to do that?",
     "confirm_postinstall": "You are about to launch the post-installation process on the domain %s. It may take a few minutes, *do not interrupt the operation*.",
     "confirm_restore": "Are you sure you want to restore %s ?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,7 +75,7 @@
     "confirm_delete": "Are you sure you want to delete %s ?",
     "confirm_firewall_open": "Are you sure you want to open port %s? (protocol: %s, connection: %s)",
     "confirm_firewall_close": "Are you sure you want to close port %s? (protocol: %s, connection: %s)",
-    "confirm_install_custom_app": "Installing 3rd party applications may compromise the security of your system. Use at your own risk.",
+    "confirm_install_custom_app": "WARNING ! Installing 3rd party applications may compromise the integrity and security of your system. You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",
     "confirm_install_domain_root": "You will not be able to install any other app on %s. Continue ?",
     "confirm_install_app_warning": "Warning : this application may work but is not well-integrated in YunoHost. Some features such as single sign-on and backup/restore might not be available.",
     "confirm_install_app_danger": "WARNING ! This application is still experimental and is likely to break your system ! You should probably NOT install it unless you know what you are doing. Are you willing to take that risk ?",


### PR DESCRIPTION
### Problem

Currently there is no warning shown when installing experimental or low quality apps. We should add some to discourage users installing apps likely to break their system ...

### Solution

- Ask for confirmation when installing low quality or broken/experimental apps
    - A "good quality" app is defined as working + level >= 3
    - A "low-quality app is defined as working + level = 1 or 2
    - A broken / experimental app is all other apps
- Increase spookiness of message when installing apps from custom URL