### PR TITLE
Add a warning on home page about YunoHost's version being obsolete

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -224,6 +224,7 @@
     "passwords_dont_match": "Passwords don't match",
     "passwords_too_short": "Password is too short",
     "path": "Path",
+    "obsolete_version": "You are running an obsolete version of YunoHost. The YunoHost team highly recommend to run the migration to YunoHost 3.x / Stretch available in Tools > Migrations. More information can be found on <a href='https://yunohost.org/#/jessie_stretch_migration'>this page in the documentation</a>",
     "path_url": "Path",
     "port": "Port",
     "ports": "Ports",

--- a/src/views/home.ms
+++ b/src/views/home.ms
@@ -1,3 +1,7 @@
+<p class="alert alert-warning">
+{{t 'obsolete_version' }}
+</p>
+
 <div class="list-group">
     <a href="#/users" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>


### PR DESCRIPTION
### Problem

Some admins might still be on Jessie and might have not seen the migration about Stretch (e.g. if they don't follow the announcements on the forum). We need to encourage them to switch to Stretch because Jessie is more and more obsolete.

### Solution

Add a warning message on the home page. (N.B. : this is to be merged and release on jessie)