### PR TITLE
Do not fail miserably if we don't have proper json during error 500

### DIFF
--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -122,9 +122,18 @@
                             }
                             // 500
                             else if (xhr.status == 500) {
-                                error_log = JSON.parse(xhr.responseText);
-                                error_log.route = error_log.route.join(' ') + '\n';
-                                error_log.arguments = JSON.stringify(error_log.arguments);
+                                try {
+                                    error_log = JSON.parse(xhr.responseText);
+                                    error_log.route = error_log.route.join(' ') + '\n';
+                                    error_log.arguments = JSON.stringify(error_log.arguments);
+                                }
+                                catch (e)
+                                {
+                                    error_log = {};
+                                    error_log.route = "Failed to parse route";
+                                    error_log.arguments = "Failed to parse arguments";
+                                    error_log.traceback = xhr.responseText;
+                                }
                                 c.flash('fail', y18n.t('internal_exception', [error_log.route, error_log.arguments, error_log.traceback]));
                             }
                             // 502 Bad gateway means API is down


### PR DESCRIPTION
### Problem

Currently, if we encounter an error 500, we assume we got a json with a few properties defined and attempt to parse it. However for some reason we might not get such a json and the admin will fail miserably and pacman will keep running forever (and nothing is displayed to the user).

This is related to https://github.com/YunoHost/issues/issues/1196 though I don't expect if to be 100% of the root cause.

### Solution

I don't know what's a proper solution, I just added a quick and dirty try/catch so that the code doesn't fail miserably and shows the raw `xhr.responseText` as traceback. At least pacman stops moving and something is shown to the user :/ 