### PR TITLE
Remove dependency to GET /version to fetch version

### DIFF
--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -78,6 +78,8 @@
             });
 
             c.api("/diagnosis", function(data) {
+                versions = data.packages;
+                $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
                 if (data.security["CVE-2017-5754"].vulnerable) {
                     c.flash('danger', y18n.t('meltdown'));
                 }

--- a/src/js/yunohost/controllers/home.js
+++ b/src/js/yunohost/controllers/home.js
@@ -3,8 +3,6 @@
     var app = Sammy.apps['#main'];
     var store = app.store;
 
-    var initial_checks_already_performed = false;
-
     /**
      * Home
      *
@@ -12,85 +10,10 @@
 
      // Home page
     app.get('#/', function (c) {
-        if (initial_checks_already_performed)
-        {
-            c.view("home");
-        }
-        else c.api('/users', function(data) {
-            // Warn admin if no users are created.
-            if (typeof data.users !== 'undefined' && data.users.length === 0) {
-                c.flash('warning', y18n.t('warning_first_user'));
-            }
-
-            // Get security feed and display new items
-            var securityFeed = 'https://yunohost.org/security.rss';
-            var forumUrl = 'https://forum.yunohost.org';
-
-            $.ajax({
-                url: securityFeed,
-                // dataType: (jQuery.browser.msie) ? "text" : "xml",
-                dataType: "xml"
-            })
-            .done(function(xml){
-                // Get viewed security alerts from cookie
-                var viewedItems = Cookies.get('ynhSecurityViewedItems') || [];
-
-                // Get 6 month earlier date
-                var SixMonthEarlier = new Date();
-                SixMonthEarlier.setMonth(SixMonthEarlier.getMonth() - 6);
-
-                // Loop through items in a reverse order (older first)
-                $($('item', xml).get().reverse()).each(function(k, v) {
-                    var link = $('link', v).text();
-                    if (typeof link == 'string' && link !== '' && link.charAt(0) == '/') {
-                        link = forumUrl+link;
-                    }
-
-                    // var description=$('description', v).text();
-                    // description=description.replace('href="/','href="'+forumUrl+'/');
-
-                    var item = {
-                        guid: $('guid', v).text(),
-                        title: $('title', v).text(),
-                        url: link,
-                        // desc: description,
-                        date: new Date($('pubDate', v).text()),
-                    };
-
-                    // If item is not already viewed and is not older than 6 month
-                    if (viewedItems.indexOf(item.guid) === -1 && (item.date.getTime() > SixMonthEarlier.getTime())) {
-                        // Show security message to administrator
-                        var warning = item.title + ' - ' + 
-                                                item.date.toISOString().substring(0, 10) + 
-                                                ' (<a href="'+ item.url +'" class="alert-link" target="_blank">'+y18n.t('read_more')+'</a>)';
-                        c.flash('warning', warning);
-                        // Store viewed item
-                        viewedItems.push(item.guid);
-                    }
-                });
-                // Saved viewed items to cookie
-                Cookies.set('ynhSecurityViewedItems', viewedItems, {
-                    expires: 7
-                });
-            })
-            .fail(function() {
-                c.flash('fail', y18n.t('error_retrieve_feed', [securityFeed]));
-            });
-
-            c.api("/diagnosis", function(data) {
-                versions = data.packages;
-                $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
-                if (data.security["CVE-2017-5754"].vulnerable) {
-                    c.flash('danger', y18n.t('meltdown'));
-                }
-            });
-
-            initial_checks_already_performed = true;
-            c.view('home');
-        });
+        c.view("home");
+        // N.B : if you need to run stuff at login time,
+        // see js/events.js instead
     });
-
-
 
     /**
      * Login

--- a/src/js/yunohost/controllers/monitor.js
+++ b/src/js/yunohost/controllers/monitor.js
@@ -30,8 +30,8 @@
                             delete monitorData.network.usage.lo;
 
                             // Get YunoHost versions too
-                            c.api('/version', function(versions) {
-                                monitorData.versions = versions;
+                            c.api('/diagnosis', function(diagnosis) {
+                                monitorData.versions = diagnosis.packages;
                                 c.view('tools/tools_monitoring', monitorData);
                             });
                         });

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -223,8 +223,8 @@
 
     // Packages version
     app.get('#/tools/versions', function (c) {
-        c.api('/version', function(versions) {
-            c.view('tools/tools_versions', {'versions' : versions});
+        c.api('/diagnosis', function(diagnosis) {
+            c.view('tools/tools_versions', {'versions' : diagnosis.packages });
         });
     });
 

--- a/src/js/yunohost/events.js
+++ b/src/js/yunohost/events.js
@@ -8,9 +8,6 @@
      *
      */
     app.bind('login', function(e, data) {
-        this.api('/version', function(versions) {
-            $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
-        });
     });
 
     app.bind('logout', function(e, data) {

--- a/src/js/yunohost/events.js
+++ b/src/js/yunohost/events.js
@@ -66,7 +66,6 @@
                 });
             })
             .fail(function(stuff) {
-                console.log(stuff);
                 c.flash('fail', y18n.t('error_retrieve_feed', [securityFeed]));
             });
 
@@ -76,6 +75,7 @@
                 if (data.security["CVE-2017-5754"].vulnerable) {
                     c.flash('danger', y18n.t('meltdown'));
                 }
+                $('div.loader').remove();
             });
         });
     });

--- a/src/js/yunohost/events.js
+++ b/src/js/yunohost/events.js
@@ -8,6 +8,76 @@
      *
      */
     app.bind('login', function(e, data) {
+        c.api('/users', function(data) {
+            // Warn admin if no users are created.
+            if (typeof data.users !== 'undefined' && data.users.length === 0) {
+                c.flash('warning', y18n.t('warning_first_user'));
+            }
+
+            // Get security feed and display new items
+            var securityFeed = 'https://yunohost.org/security.rss';
+            var forumUrl = 'https://forum.yunohost.org';
+
+            $.ajax({
+                url: securityFeed,
+                // dataType: (jQuery.browser.msie) ? "text" : "xml",
+                dataType: "xml"
+            })
+            .done(function(xml){
+                // Get viewed security alerts from cookie
+                var viewedItems = Cookies.get('ynhSecurityViewedItems') || [];
+
+                // Get 6 month earlier date
+                var SixMonthEarlier = new Date();
+                SixMonthEarlier.setMonth(SixMonthEarlier.getMonth() - 6);
+
+                // Loop through items in a reverse order (older first)
+                $($('item', xml).get().reverse()).each(function(k, v) {
+                    var link = $('link', v).text();
+                    if (typeof link == 'string' && link !== '' && link.charAt(0) == '/') {
+                        link = forumUrl+link;
+                    }
+
+                    // var description=$('description', v).text();
+                    // description=description.replace('href="/','href="'+forumUrl+'/');
+
+                    var item = {
+                        guid: $('guid', v).text(),
+                        title: $('title', v).text(),
+                        url: link,
+                        // desc: description,
+                        date: new Date($('pubDate', v).text()),
+                    };
+
+                    // If item is not already viewed and is not older than 6 month
+                    if (viewedItems.indexOf(item.guid) === -1 && (item.date.getTime() > SixMonthEarlier.getTime())) {
+                        // Show security message to administrator
+                        var warning = item.title + ' - ' +
+                                                item.date.toISOString().substring(0, 10) +
+                                                ' (<a href="'+ item.url +'" class="alert-link" target="_blank">'+y18n.t('read_more')+'</a>)';
+                        c.flash('warning', warning);
+                        // Store viewed item
+                        viewedItems.push(item.guid);i
+                    }
+                });
+                // Saved viewed items to cookie
+                Cookies.set('ynhSecurityViewedItems', viewedItems, {
+                    expires: 7
+                });
+            })
+            .fail(function(stuff) {
+                console.log(stuff);
+                c.flash('fail', y18n.t('error_retrieve_feed', [securityFeed]));
+            });
+
+            c.api("/diagnosis", function(data) {
+                versions = data.packages;
+                $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
+                if (data.security["CVE-2017-5754"].vulnerable) {
+                    c.flash('danger', y18n.t('meltdown'));
+                }
+            });
+        });
     });
 
     app.bind('logout', function(e, data) {

--- a/src/js/yunohost/main.js
+++ b/src/js/yunohost/main.js
@@ -149,13 +149,6 @@
             // Store url
             sam.store.set('url', window.location.hostname + '/yunohost/api');
 
-            // Get YunoHost version
-            if (sam.store.get('connected')) {
-                this.api('/version', function(versions) {
-                    $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
-                });
-            }
-
             // Flash messages
             var flashMessage = $('#flashMessage');
             $('#toggle-btn', flashMessage).click(function(e) {

--- a/src/js/yunohost/main.js
+++ b/src/js/yunohost/main.js
@@ -149,6 +149,13 @@
             // Store url
             sam.store.set('url', window.location.hostname + '/yunohost/api');
 
+            if (sam.store.get('connected')) {
+                this.api('/diagnosis', function(diagnosis) {
+                    versions = diagnosis.packages;
+                    $('#yunohost-version').html(y18n.t('footer_version', [versions.yunohost.version, versions.yunohost.repo]));
+                });
+            }
+
             // Flash messages
             var flashMessage = $('#flashMessage');
             $('#toggle-btn', flashMessage).click(function(e) {


### PR DESCRIPTION
### Problem 

See https://github.com/YunoHost/issues/issues/703 and https://github.com/YunoHost/yunohost/pull/291

It's easy to remove `/version` from `yunohost-api`, but the admin relies on it in several place. This problem was blocking for https://github.com/YunoHost/yunohost/pull/291 ...

### Solution

I tried to have an elegant solution through the moulinette but it was a complete technical mess so I gave up this. Instead, I just rely on the diagnosis route.

The version in the footer is updated after fetching the diagnosis (also used for the meltdown vulnerability check)

I also move the whole "initial checks" stuff to events.js realizing it's probably cleaner and relevant.

### Status

Tested, should be working

