### PR TITLE
Don't use version for cache control

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,6 +10,12 @@ do_configure() {
 
   # Set document root permissions
   chown -R root:root /usr/share/yunohost/admin
+
+  # Replace RANDOMHASH with a random hash to invalidate
+  # old cache ... we generate this locally on each machine
+  # to avoid leaking stuff like the version
+  RANDOMHASH=$(openssl rand -hex 4)
+  sed -i 's/RANDOMHASH/$RANDOMHASH/g' /usr/share/yunohost/admin/index.html
 }
 
 # summary of how this script can be called:

--- a/debian/postinst
+++ b/debian/postinst
@@ -11,11 +11,11 @@ do_configure() {
   # Set document root permissions
   chown -R root:root /usr/share/yunohost/admin
 
-  # Replace RANDOMHASH with a random hash to invalidate
+  # Replace RANDOMID with a random hash to invalidate
   # old cache ... we generate this locally on each machine
   # to avoid leaking stuff like the version
-  RANDOMHASH=$(openssl rand -hex 4)
-  sed -i 's/RANDOMHASH/$RANDOMHASH/g' /usr/share/yunohost/admin/index.html
+  RANDOMID=$(openssl rand -hex 4)
+  sed -i "s/RANDOMID/$RANDOMID/g" /usr/share/yunohost/admin/index.html
 }
 
 # summary of how this script can be called:

--- a/debian/rules
+++ b/debian/rules
@@ -15,10 +15,6 @@ TMPDIR = $$(pwd)/debian/yunohost-admin
 	dh  $@
 
 override_dh_auto_build:
-	# Replace VERSION with current package version to prevent web browser
-	# to serve old css/js files
-	sed -i 's/VERSION/$(DEBVERS)/g' src/index.html
-
 	# Run npm/bower/gulp
 	cd src ; npm --progress false --loglevel warn --color false install
 	cd src ; node_modules/gulp/bin/gulp.js build

--- a/src/index.html
+++ b/src/index.html
@@ -7,9 +7,9 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="user-scalable=no, width=device-width, height=device-height" />
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" media="screen" href="dist/css/style.min.css?version=VERSION">
+    <link rel="stylesheet" media="screen" href="dist/css/style.min.css?version=RANDOMHASH">
     <link rel="shortcut icon" href="dist/img/ynhadmin_icon.png">
-    <script type="text/javascript" src="dist/js/script.min.js?version=VERSION"></script>
+    <script type="text/javascript" src="dist/js/script.min.js?version=RANDOMHASH"></script>
 </head>
 <body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -7,9 +7,9 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="user-scalable=no, width=device-width, height=device-height" />
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" media="screen" href="dist/css/style.min.css?version=RANDOMHASH">
+    <link rel="stylesheet" media="screen" href="dist/css/style.min.css?version=RANDOMID">
     <link rel="shortcut icon" href="dist/img/ynhadmin_icon.png">
-    <script type="text/javascript" src="dist/js/script.min.js?version=RANDOMHASH"></script>
+    <script type="text/javascript" src="dist/js/script.min.js?version=RANDOMID"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Problem

Soooo Goffanon spotted this issue in that we *still* leak the version number in the `<head>` of the webadmin ... this is in fact used to automatically invalidate the cache so we can't simply remove it ...

## Solution

A trick I found (though not really tested yet) is instead to generate on each local machine a random hash an replace it at install time ...

However, as said on the chat, I am not sure how all of this attempt to leak the version number is worth it ... In practice, since all yunohost admin assets (js, css, ms, ...) are accessible publicly, an attacker could look at the history of changes on those assets to create a script that would do a bunch of request and infer the version number from the hash of the assets ...

## Status

Not really tested, to be discussed