### PR TITLE
[enh] Display version inside app info

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -371,6 +371,7 @@
     "users_new": "New user",
     "users_no": "No users.",
     "versions": "Versions",
+    "version": "Version",
     "view_user_profile": "View %s's profile",
     "warning_first_user": "You probably need to <a href='#/users/create' class='alert-link'>create a user</a> first.",
     "write": "Write",

--- a/src/views/app/app_info.ms
+++ b/src/views/app/app_info.ms
@@ -19,6 +19,8 @@
             <dd>{{settings.label}}</dd>
             <dt>{{t 'description'}}</dt>
             <dd>{{description}}</dd>
+            <dt>{{t 'version'}}</dt>
+            <dd>{{manifest.version}}</dd>
             <dt>{{t 'multi_instance'}}</dt>
             <dd>{{manifest.multi_instance}}</dd>
             <dt>{{t 'install_time'}}</dt>

--- a/src/views/app/app_install.ms
+++ b/src/views/app/app_install.ms
@@ -19,6 +19,8 @@
             <dd>{{id}}</dd>
             <dt>{{t 'description'}}</dt>
             <dd>{{description}}</dd>
+            <dt>{{t 'version'}}</dt>
+            <dd>{{manifest.version}}</dd>
             <dt>{{t 'multi_instance'}}</dt>
             <dd>{{manifest.multi_instance}}</dd>
         </dl>


### PR DESCRIPTION
Since the version number is available, we can display it:
https://github.com/YunoHost/yunohost/blob/bdc78530cfebad160d297e93cfc151f232dfb593/src/yunohost/app.py#L379

Tested, ~noticed a little problem, version is displayed **version** and not **Version** with a big **V**, I don't know why or where to look to fix it.~ works well!