### PR TITLE
[enh] Improve log list

### DIFF
--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -97,9 +97,9 @@
 
     // Display journals list
     app.get('#/tools/logs', function (c) {
-        c.api("/logs", function(categories) {
+        c.api("/logs?limit=25&with_details", function(categories) {
             data = [];
-            icons = {
+            category_icons = {
                 'operation': 'wrench',
                 'history': 'history',
                 'package': 'puzzle-piece',
@@ -108,11 +108,20 @@
                 'service': 'cog',
                 'app': 'cubes'
             }
+            success_icons = {
+                true: 'check text-success',
+                false: 'close text-danger',
+                '?': 'question text-warning'
+            }
             for (var category in categories) {
+                for (var log in categories[category])
+                {
+                    categories[category][log].success_icon = success_icons[categories[category][log].success]
+                }
                 if (categories.hasOwnProperty(category)) {
                     data.push({
                         key:category,
-                        icon:(category in icons)?icons[category]:'info-circle',
+                        icon:(category in category_icons)?category_icons[category]:'info-circle',
                         value:categories[category]
                     });
                 }

--- a/src/views/tools/tools_log.ms
+++ b/src/views/tools/tools_log.ms
@@ -2,7 +2,11 @@
     <a href="#/" ><i class="fa-home"></i><span class="sr-only">{{t 'home'}}</span></a>
     <a href="#/tools">{{t 'tools'}}</a>
     <a href="#/tools/logs">{{t 'logs'}}</a>
+    {{#if log.name}}
+    <a href="#/tools/logs/{{ log.name }}">{{ log.name }}</a>
+    {{else}}
     <a href="#/tools/logs/{{ log.log_path }}">{{ log.log_path }}</a>
+    {{/if}}
 </div>
 
 <div class="actions-group">

--- a/src/views/tools/tools_logs.ms
+++ b/src/views/tools/tools_logs.ms
@@ -22,7 +22,8 @@
         <div id="collapse-{{key}}" class="panel-collapse{{#if @first}}{{else}} collapse{{/if}}" role="tabpanel" aria-labelledby="heading-{{key}}">
             <div class="list-group">
             {{#value}}
-                <a href="#/tools/logs/{{ name }}" class="list-group-item" title='{{formatTime started_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}'><small style="margin-right:20px;" >{{formatRelative started_at}}</small> {{ description }}</a>
+                <a href="#/tools/logs/{{ name }}" class="list-group-item" title='{{formatTime started_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}'><small style="margin-right:20px;" >{{formatRelative started_at}}</small>
+                <span class="fa-fw fa-{{success_icon}}"></span> {{ description }}</a>
             {{/value}}
             </div>
         </div>


### PR DESCRIPTION
### Problem 

The current log list is a bit meh, and in particular it's not obvious which operations failed

### Solution

N.B. : this depends on https://github.com/YunoHost/yunohost/pull/716

- Add an icon showing the success state of the operation (failed, success or ?) ... cf screenshot
- Also, in the page showing a specific log, fix the breadcrumb to use the log name instead of the log path which is really too technical / complicated


![2019-04-24-201735_1366x768_scrot](https://user-images.githubusercontent.com/4533074/56683621-329da880-66ce-11e9-96b4-65906cc66e35.png)
