### PR TITLE
[enh] Convert ascii progress bars to bootstrap progress bar

### DIFF
--- a/src/css/style.less
+++ b/src/css/style.less
@@ -558,6 +558,14 @@ input[type='radio'].nice-radio {
    border-radius: 5px;
 }
 
+.messages .progress-bar-striped {
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.5) 75%, transparent 75%, transparent);
+}
+
+.messages .progress-bar.active {
+   animation-direction: reverse;
+}
+
 /** custom badges **/
 .badge {
     &.badge-default {

--- a/src/css/style.less
+++ b/src/css/style.less
@@ -550,6 +550,13 @@ input[type='radio'].nice-radio {
     }
 }
 
+.messages .progress {
+   display:inline-block;
+   height:0.8em;
+   margin-bottom: 0;
+   width: 200px;
+   border-radius: 5px;
+}
 
 /** custom badges **/
 .badge {

--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -50,7 +50,7 @@
                 done = done * 100 / total;
                 ongoing = ongoing * 100 / total;
                 // Actually build the message with the progress bar
-                message = '<div class="progress"><div class="progress-bar progress-bar-success" role="progressbar" style="width:'+done+'%"></div><div class="progress-bar" role="progressbar" style="width:'+ongoing+'%;"></div></div><p style="display: inline-block;">' + message + '</p>';
+                message = '<div class="progress"><div class="progress-bar progress-bar-success" role="progressbar" style="width:'+done+'%"></div><div class="progress-bar progress-bar-striped active" role="progressbar" style="width:'+ongoing+'%;"></div></div><p style="display: inline-block;">' + message + '</p>';
             }
             else
             {

--- a/src/js/yunohost/helpers.js
+++ b/src/js/yunohost/helpers.js
@@ -35,10 +35,31 @@
 
             message = message.split("\n").join("<br />");
 
+            // If the message starts with a progress bar
+            progressbar = message.match(/^\[#*\+*\.*\] > /);
+            if (progressbar)
+            {
+                progressbar = progressbar[0];
+                // Remove the progress bar from the mesage
+                message = message.replace(progressbar,"");
+                // Compute percent
+                done = (progressbar.match(/#/g)||[]).length;
+                ongoing = (progressbar.match(/\+/g)||[]).length;
+                remaining = (progressbar.match(/\./g)||[]).length;
+                total = done + ongoing + remaining;
+                done = done * 100 / total;
+                ongoing = ongoing * 100 / total;
+                // Actually build the message with the progress bar
+                message = '<div class="progress"><div class="progress-bar progress-bar-success" role="progressbar" style="width:'+done+'%"></div><div class="progress-bar" role="progressbar" style="width:'+ongoing+'%;"></div></div><p style="display: inline-block;">' + message + '</p>';
+            }
+            else
+            {
+                message = '<p>'+message+'</p>';
+            }
+
             // Add message
             $('#flashMessage .messages')
-                .prepend('<div class="alert alert-'+ level +'">'+
-                              '<p>'+ message +'</p></div>');
+                .prepend('<div class="alert alert-'+ level +'">'+message+'</div>');
 
             // Scroll to top to view new messages
             $('#flashMessage').scrollTop(0);


### PR DESCRIPTION
### The problem

`ynh_script_progression` is awesome, but the progress bar rendering in the webadmin is a bit funky because of the use of non-monospace font ... Especially the 'dot' which is small compared to the width of the `#`. But that's understood since that's designed for CLI anyway ;)

![2019-05-15-214058_1366x768_scrot](https://user-images.githubusercontent.com/4533074/57804380-d83ab980-775a-11e9-9a11-e49e09c9664a.png)

### Proposed solution

Change the display code to detect progress bars using a regex, and inject a bootstrap-based progress bar instead : 

![2019-05-15-213751_1366x768_scrot](https://user-images.githubusercontent.com/4533074/57804469-015b4a00-775b-11e9-9af7-ce947ce372ed.png)

Animated version (with https://github.com/YunoHost/yunohost/pull/724 enabled)

![ezgif-2-6b04a3cd9d3a](https://user-images.githubusercontent.com/4533074/57868022-7c2b7000-7802-11e9-87a7-a74bf483c188.gif)

### How to test

Pull the branch and try to install an app like Wordpress


