### PR TITLE
Set minlength/maxlength on admin password form

### DIFF
--- a/src/views/postinstall/postinstall_3.ms
+++ b/src/views/postinstall/postinstall_3.ms
@@ -12,14 +12,14 @@
     <div class="form-group">
         <label for="password" class="col-sm-4 control-label">{{t 'administration_password'}}</label>
         <div class="col-sm-8">
-            <input required type="password" id="password" name="password" class="form-control" placeholder="••••••">
+            <input required type="password" id="password" name="password" class="form-control" minlength="8" maxlength="127" placeholder="••••••">
         </div>
     </div>
 
     <div class="form-group">
         <label for="confirmation" class="col-sm-4 control-label">{{t 'password_confirmation'}}</label>
         <div class="col-sm-8">
-            <input required type="password" id="confirmation" name="confirmation" class="form-control" placeholder="••••••">
+            <input required type="password" id="confirmation" name="confirmation" class="form-control" minlength="8" maxlength="127" placeholder="••••••">
         </div>
     </div>
 


### PR DESCRIPTION
References:
  * https://github.com/YunoHost/yunohost/blob/b3d29238c4bba040b7ad5afdbcc2be7c6a50058d/src/yunohost/tools.py#L129
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-minlength
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-maxlength

This matches the `yunohost` core logic to ensure >=8, <127 on the form level.