### PR TITLE
Do not show URL if app doesn't have one

### DIFF
--- a/src/views/app/app_info.ms
+++ b/src/views/app/app_info.ms
@@ -25,8 +25,10 @@
             <dd>{{manifest.multi_instance}}</dd>
             <dt>{{t 'install_time'}}</dt>
             <dd>{{formatTime install_time day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>
-            <dt>{{t 'url'}}</dt>
-            <dd><a href="https://{{settings.domain}}{{settings.path}}" target="_blank">https://{{settings.domain}}{{settings.path}}</a></dd>
+            {{#if settings.domain}}
+                <dt>{{t 'url'}}</dt>
+                <dd><a href="https://{{settings.domain}}{{settings.path}}" target="_blank">https://{{settings.domain}}{{settings.path}}</a></dd>
+            {{/if}}
         </dl>
     </div>
 </div>


### PR DESCRIPTION
For some app that haven't url, admin panel displays **https://**, this could be confusing.

https://github.com/YunoHost-Apps/synapse_ynh/issues/130

Display url only if settings.domain exists