### PR TITLE
[enh] Add current / new versions in update view

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -153,6 +153,7 @@
     "footer_version": "Powered by <a href='https://yunohost.org'>YunoHost</a> %s (%s).",
     "form_input_example": "Example: %s",
     "free": "Free",
+    "from_to": "from %s to %s",
     "fs_type": "FS Type",
     "gateway": "Gateway: ",
     "good_practices_about_admin_password": "You are now about to define a new admin password. The password should be at least 8 characters - though it is good practice to use longer password (i.e. a passphrase) and/or to use various kind of characters (uppercase, lowercase, digits and special characters).",

--- a/src/views/update/update.ms
+++ b/src/views/update/update.ms
@@ -14,7 +14,7 @@
         {{#system}}
         <div class="list-group-item">
             <h3 class="list-group-item-heading">
-                {{name}} <small>{{fullname}}</small>
+                {{name}} <small>({{t 'from_to' current_version new_version}}) </small>
             </h3>
         </div>
         {{/system}}
@@ -39,6 +39,7 @@
         <div class="list-group-item clearfix">
             <a href="#/upgrade/apps/{{id}}" role="button" class="btn btn-success pull-right">{{t 'system_upgrade_btn'}}</a>
             <h3 class="list-group-item-heading">{{label}} <small>{{id}}</small></h3>
+            <p class="list-group-item-text">{{t 'from_to' current_version new_version}}</p>
         </div>
         {{/apps}}
     </div>


### PR DESCRIPTION
### Problem

The current update view doesn't display the current / new version of apps, so you don't know what you're really upgrading (and personally that makes me kinda suspicious and unlikely to click the upgrade button)

### Solution

Display 'from X to Y' version in the view (c.f. https://github.com/YunoHost/yunohost/pull/735 )

