### PR TITLE
[fix] Progress bars in logs top bar are confusing

### DIFF
--- a/src/css/style.less
+++ b/src/css/style.less
@@ -558,6 +558,10 @@ input[type='radio'].nice-radio {
    border-radius: 5px;
 }
 
+.messages div:not(:first-child) .progress {
+    display: none;
+}
+
 .messages .progress-bar-striped {
     background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.5) 75%, transparent 75%, transparent);
 }


### PR DESCRIPTION
I know we have speak about freazing change until 3.7 will be released, but yesterday Jennifer has waited the end of progress bars during 1 day like José during the Brique Camp.

So this small change fix that...