### PR TITLE
Merge Upgrades + Services + Tools into a 'System' section ?

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -315,6 +315,7 @@
     "tools_shutdown_done": "Shutting down...",
     "tools_shuttingdown": "Your server is powering off. As long as your server is off, you won't be able to use the web administration.",
     "tools_shutdown_reboot": "Shutdown/Reboot",
+    "upgrades": "Upgrades",
     "udp": "UDP",
     "unauthorized": "Unauthorized",
     "unignore": "Unignore",

--- a/src/views/home.ms
+++ b/src/views/home.ms
@@ -11,17 +11,9 @@
         <span class="pull-right fa-chevron-right"></span>
         <h2 class="list-group-item-heading"><span class="fa-fw fa-cubes"></span> {{t 'applications'}}</h2>
     </a>
-    <a href="#/update" class="list-group-item slide">
-        <span class="fa-chevron-right pull-right"></span>
-        <h2 class="list-group-item-heading"><span class="fa-fw fa-refresh"></span> {{t 'system_update'}}</h2>
-    </a>
-    <a href="#/services" class="list-group-item slide clearfix">
-        <span class="pull-right fa-chevron-right"></span>
-        <h2 class="list-group-item-heading"><span class="fa-fw fa-cog"></span> {{t 'services'}}</h2>
-    </a>
     <a href="#/tools" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>
-        <h2 class="list-group-item-heading"><span class="fa-fw fa-wrench"></span> {{t 'tools'}}</h2>
+        <h2 class="list-group-item-heading"><span class="fa-fw fa-server"></span> {{t 'system'}}</h2>
     </a>
     <a href="#/diagnosis" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>

--- a/src/views/tools/tools_list.ms
+++ b/src/views/tools/tools_list.ms
@@ -6,6 +6,10 @@
 <div class="separator"></div>
 
 <div class="list-group">
+    <a href="#/update" class="list-group-item slide">
+        <span class="fa-chevron-right pull-right"></span>
+        <h2 class="list-group-item-heading">{{t 'upgrades'}}</h2>
+    </a>
     <a href="#/tools/logs" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>
         <h2 class="list-group-item-heading">{{t 'logs'}}</h2>
@@ -13,6 +17,10 @@
     <a href="#/tools/migrations" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>
         <h2 class="list-group-item-heading">{{t 'migrations'}}</h2>
+    </a>
+    <a href="#/services" class="list-group-item slide clearfix">
+        <span class="pull-right fa-chevron-right"></span>
+        <h2 class="list-group-item-heading"> {{t 'services'}}</h2>
     </a>
     <a href="#/tools/reboot" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>


### PR DESCRIPTION
Idk, that's a rough draft to see what are people's thoughts about this.

- Imho our current 'Tools' is more like 'System' management stuff.
- Imho 'Services' are a low-level stuff and shouldn't be "advertised" about on the home page.
- Upgrades are also kind of a system management thing
- On the mid term, should also merge the 'Migration' screen somehow in the Upgrades screen ..
- Maybe put the Log section on the home, idk

Here are some screenshot of what it'd look like (there's still some work to fully propagate everything if that's really what we wanna do)

![2019-11-07-230915_1366x768_scrot](https://user-images.githubusercontent.com/4533074/68432245-5d57d600-01b4-11ea-9e36-e99efab015b5.png)

![2019-11-07-230924_1366x768_scrot](https://user-images.githubusercontent.com/4533074/68432240-5b8e1280-01b4-11ea-9b31-881044d0ddb4.png)