### PR TITLE
[enh] Sort domains alphabetically

### DIFF
--- a/src/js/yunohost/controllers/domains.js
+++ b/src/js/yunohost/controllers/domains.js
@@ -14,7 +14,7 @@
             c.api('PUT', '/domains/main', {}, function(data2) {
                 var domains = [];
                 $.each(data.domains, function(k, domain) {
-                    domains.push({
+                    domains.unshift({
                         url: domain,
                         main: (domain == data2.current_main_domain) ? true : false
                     });


### PR DESCRIPTION
## The problem

Domains are randomly displayed on the domain page
 yunohost/issues#1355

## Solution

Sort domains alphabetically, by top domains

## PR Status

...

## How to test

Add many domains and subdomains
Use yunohost/yunohost#860
Go to domain page

(I was unable to test (ynh-dev errors…) but it is a minor change so I suppose it works ^^)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
