### PR TITLE
[debian/control] upgrade debhelper and nodejs requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: extra
 Maintainer: YunoHost Contributors <contrib@yunohost.org>
 Build-Depends: debhelper (>=12)
- , nodejs (>=10.15.2), git
+ , nodejs (>=10.15.2), npm (>=5.8.0), git
 Standards-Version: 3.9.6
 Homepage: https://yunohost.org/
 

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: yunohost-admin
 Section: utils
 Priority: extra
 Maintainer: YunoHost Contributors <contrib@yunohost.org>
-Build-Depends: debhelper (>=9)
- , nodejs (>=4.4.0), git
+Build-Depends: debhelper (>=12)
+ , nodejs (>=10.15.2), git
 Standards-Version: 3.9.6
 Homepage: https://yunohost.org/
 


### PR DESCRIPTION
Trying to push buster forward, these changes are probably not necessary. If anyone has an opinion. 