### PR TITLE
[enh] Highlight error/warnings/... in tools > logs

### DIFF
--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -143,12 +143,12 @@
                 "next_number": log.logs.length == number ? number * 10:false,
                 "locale": y18n.locale
             }, function() {
-                log = $("#log").html();
+                log = $("#main #log").html();
                 log = log.replace(/.*: ERROR - .*/g, function (match) { return '<span class="alert-danger">'+match+'</span>'});
                 log = log.replace(/.*: WARNING - .*/g, function (match) { return '<span class="alert-warning">'+match+'</span>'});
                 log = log.replace(/.*: SUCCESS - .*/g, function (match) { return '<span class="alert-success">'+match+'</span>'});
                 log = log.replace(/.*: INFO - .*/g, function (match) { return '<span class="alert-info">'+match+'</span>'});
-                $("#log").html(log);
+                $("#main #log").html(log);
 
                 // Configure behavior for the button to share log on Yunohost (it calls display --share)
                 $('button[data-action="share"]').on("click", function() {

--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -137,11 +137,19 @@
                     log.metadata.env = log.metadata.args
                 }
             }
+
             c.view('tools/tools_log', {
                 "log": log,
                 "next_number": log.logs.length == number ? number * 10:false,
                 "locale": y18n.locale
             }, function() {
+                log = $("#log").html();
+                log = log.replace(/.*: ERROR - .*/g, function (match) { return '<span class="alert-danger">'+match+'</span>'});
+                log = log.replace(/.*: WARNING - .*/g, function (match) { return '<span class="alert-warning">'+match+'</span>'});
+                log = log.replace(/.*: SUCCESS - .*/g, function (match) { return '<span class="alert-success">'+match+'</span>'});
+                log = log.replace(/.*: INFO - .*/g, function (match) { return '<span class="alert-info">'+match+'</span>'});
+                $("#log").html(log);
+
                 // Configure behavior for the button to share log on Yunohost (it calls display --share)
                 $('button[data-action="share"]').on("click", function() {
                     c.api('GET', '/logs/display?path='+$(this).data('log-id')+'&share', {},


### PR DESCRIPTION
Today I had this not-so-uncommon situation where a user had a failed app install, ask him to share the log, and right after sharing the log, the user realize he could had debug the whole thing himself because the warning was pretty explicit (system ran out of space)

We regularly have this situation where user could debug themselves just looking at the log, but it also legitimately looks like a huge soup of text because of all the DEBUG lines. 

However, just realized tonight that it's in fact pretty cheap (c.f. the diff) to highlight the error and warning lines ...

![Capture du 2020-04-23 04-46-08](https://user-images.githubusercontent.com/4533074/80053663-bd9dc280-851d-11ea-912b-1e25f634fc02.png)
![Capture du 2020-04-23 04-45-43](https://user-images.githubusercontent.com/4533074/80053664-be365900-851d-11ea-89c1-0114f148bd4a.png)
