### PR TITLE
Select default domain in app install page

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -463,6 +463,7 @@
                     });
                 });
 
+                args[k].choices[params.domains_main].selected = true;
                 // Custom help link
                 args[k].helpLink += "<a href='#/domains'>"+y18n.t('manage_domains')+"</a>";
             }

--- a/src/js/yunohost/filters.js
+++ b/src/js/yunohost/filters.js
@@ -14,6 +14,7 @@
         req.params.domains = [];
         req.api('GET', '/domains', {}, function(data) {
             req.params.domains = data.domains;
+            req.params.domains_main = data.main;
         });
     }
 


### PR DESCRIPTION
Uses the default domain given by API to select it in the app install page (may be useful somewhere else too ?).

Needs https://github.com/YunoHost/yunohost/pull/1022 .
Fixes YunoHost/issues#1633.