### PR TITLE
Cleanup + handle suboperations in log views

### DIFF
--- a/src/js/yunohost/controllers/tools.js
+++ b/src/js/yunohost/controllers/tools.js
@@ -91,38 +91,20 @@
 
     // Display journals list
     app.get('#/tools/logs', function (c) {
-        c.api('GET', "/logs?limit=25&with_details", {}, function(categories) {
-            data = [];
-            category_icons = {
-                'operation': 'wrench',
-                'history': 'history',
-                'package': 'puzzle-piece',
-                'system': 'cogs',
-                'access': 'ban',
-                'service': 'cog',
-                'app': 'cubes'
-            }
+        c.api('GET', "/logs?limit=40&with_details", {}, function(operations) {
+            operations = operations["operation"];
             success_icons = {
                 true: 'check text-success',
                 false: 'close text-danger',
                 '?': 'question text-warning'
             }
-            for (var category in categories) {
-                for (var log in categories[category])
-                {
-                    categories[category][log].success_icon = success_icons[categories[category][log].success]
-                }
-                if (categories.hasOwnProperty(category)) {
-                    data.push({
-                        key:category,
-                        icon:(category in category_icons)?category_icons[category]:'info-circle',
-                        value:categories[category]
-                    });
-                }
+            for (var log in operations)
+            {
+                operations[log].success_icon = success_icons[operations[log].success]
             }
 
             c.view('tools/tools_logs', {
-                "data": data,
+                "operations": operations,
                 "locale": y18n.locale
             });
         });
@@ -131,16 +113,10 @@
     // One journal
     app.get(/\#\/tools\/logs\/(.*)(\?number=(\d+))?/, function (c) {
         var params = "?path=" + c.params["splat"][0];
-        var number = (c.params["number"])?c.params["number"]:50;
-        params += "&filter_irrelevant&number=" + number;
+        var number = (c.params["number"])?c.params["number"]:25;
+        params += "&filter_irrelevant&with_suboperations&number=" + number;
 
         c.api('GET', "/logs/display" + params, {}, function(log) {
-            if ('metadata' in log) {
-                if (!'env' in log.metadata && 'args' in log.metadata) {
-                    log.metadata.env = log.metadata.args
-                }
-            }
-
             c.view('tools/tools_log', {
                 "log": log,
                 "next_number": log.logs.length == number ? number * 10:false,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,6 +212,7 @@
     "passwords_too_short": "Password is too short",
     "path": "Path",
     "logs": "Logs",
+    "log_suboperations": "Sub-operations",
     "logs_operation": "Operations made on system with YunoHost",
     "logs_history": "History of command run on system",
     "logs_package": "Debian packages management history",

--- a/src/views/tools/tools_log.ms
+++ b/src/views/tools/tools_log.ms
@@ -23,6 +23,14 @@
 {{#if log.metadata.started_at}}<dt>{{t 'logs_started_at'}}</dt> <dd>{{formatTime log.metadata.started_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>
 {{/if}}{{#if log.metadata.ended_at}}<dt>{{t 'logs_ended_at'}}</dt> <dd>{{formatTime log.metadata.ended_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}</dd>{{/if}}
 {{#if log.metadata.error}}<dt>{{t 'logs_error'}}</dt> <dd>{{log.metadata.error}}</dd>{{/if}}
+        {{#if log.metadata.suboperations}}
+            <dt>{{t 'log_suboperations'}}</dt>
+        {{#log.metadata.suboperations}}
+            <dd>{{#unless success }}<span class="fa-fw fa-close text-danger"></span>{{/unless}}
+            <a href="#/tools/logs/{{ name }}">{{ description }}</a></dd>
+        {{/log.metadata.suboperations}}
+        {{/if}}
+
         </dl>
     </div>
 </div>
@@ -32,28 +40,6 @@
 <p>{{t 'operation_failed_explanation'}}</p>
 </div>
 {{/unless}}
-
-<!--
-{{#if log.metadata.env}}
-<div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="heading-context">
-        <h2 class="panel-title">
-            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-context" aria-expanded="true" aria-controls="collapse-context">
-                <span class="fa-fw fa-bug"></span>{{t 'logs_context'}}
-            </a>
-        </h2>
-    </div>
-    <div id="collapse-context" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-context">
-    <div class="panel-body">
-        <dl class="dl-horizontal" id="env">
-{{#each log.metadata.env}}<dt>{{@key}}</dt> <dd>{{.}}</dd>
-{{/each}}
-        </dl>
-    </div>
-    </div>
-</div>
-{{/if}}
--->
 
 {{/if}}
 <div class="panel panel-default">

--- a/src/views/tools/tools_logs.ms
+++ b/src/views/tools/tools_logs.ms
@@ -7,29 +7,17 @@
 <div class="separator"></div>
 
 {{#intl locales=locale}}
-{{#if data}}
-<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-{{#data}}
-{{#if value}}
-    <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="heading-{{key}}">
-            <h2 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-{{key}}" aria-expanded="true" aria-controls="collapse-{{key}}">
-                    <span class="fa-fw fa-{{icon}}"></span>{{t (concat 'logs_' key)}}
-                </a>
-            </h2>
-        </div>
-        <div id="collapse-{{key}}" class="panel-collapse{{#if @first}}{{else}} collapse{{/if}}" role="tabpanel" aria-labelledby="heading-{{key}}">
-            <div class="list-group">
-            {{#value}}
-                <a href="#/tools/logs/{{ name }}" class="list-group-item slide" title='{{formatTime started_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}'><small style="margin-right:20px;" >{{formatRelative started_at}}</small>
-                <span class="fa-fw fa-{{success_icon}}"></span> {{ description }}</a>
-            {{/value}}
-            </div>
-        </div>
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h2 class="panel-title">
+            <span class="fa-fw fa-wrench"></span>{{t 'logs_operation'}}
+        </h2>
     </div>
-{{/if}}
-{{/data}}
+    <div class="list-group">
+    {{#operations}}
+        <a href="#/tools/logs/{{ name }}" class="list-group-item slide" title='{{formatTime started_at day="numeric" month="long" year="numeric" hour="numeric" minute="numeric"}}'><small style="margin-right:20px;" >{{formatRelative started_at}}</small>
+        <span class="fa-fw fa-{{success_icon}}"></span> {{ description }}</a>
+    {{/operations}}
+    </div>
 </div>
-{{/if}}
 {{/intl}}


### PR DESCRIPTION
Follow-up of https://github.com/YunoHost/yunohost/pull/955

- Did some cleaning about some unused stuff / unecessary complexity related to "we may display other type of logs someday" but it's been a year and we don't
- Minor tweaks about the number of log / lines displayed in log list and log view
- Integrated the list of suboperations in the single log view (here I manually set the second suboperation as failed to show that it displays a red cross icon in that case)

![2020-09-02-210345_1366x768_scrot](https://user-images.githubusercontent.com/4533074/92025482-e3ef2c80-ed5f-11ea-92cb-2626510b77b8.png)
