### PR TITLE
Allow search in the app description

### DIFF
--- a/src/js/yunohost/controllers/apps.js
+++ b/src/js/yunohost/controllers/apps.js
@@ -206,7 +206,7 @@
 
                   // Check text search
                   var input = jQuery("#filter-app-cards").val().toLowerCase();
-                  if (jQuery(this).find('.app-title').text().toLowerCase().indexOf(input) <= -1) return false;
+                  if (jQuery(this).find('.app-title, .app-card-desc').text().toLowerCase().indexOf(input) <= -1) return false;
 
                   // Check subtags
                   var subtag = $(".subtag-selector button.active").data("subtag");


### PR DESCRIPTION
Related to https://github.com/YunoHost/issues/issues/1494
It allows to search in app description when searching in the install app page in the admin

You can test this change by going to Apps>Install a new app>All apps and then try to search, for example "agendav" and then "caldav". The latter should show all results containing "caldav" in their description