### PR TITLE
Trim username while new user creation to eliminate unecessary error

### DIFF
--- a/src/js/yunohost/controllers/users.js
+++ b/src/js/yunohost/controllers/users.js
@@ -207,7 +207,7 @@
         }
 
         c.params['domain'] = c.params['domain'].slice(1);
-
+        c.params['username']=c.params['username'].trim();
         c.api('POST', '/users', c.params.toHash(), function(data) {
             c.redirect_to('#/users');
         });

--- a/src/js/yunohost/controllers/users.js
+++ b/src/js/yunohost/controllers/users.js
@@ -207,7 +207,8 @@
         }
 
         c.params['domain'] = c.params['domain'].slice(1);
-        c.params['username']=c.params['username'].trim();
+        c.params['username'] = c.params['username'].trim();
+        
         c.api('POST', '/users', c.params.toHash(), function(data) {
             c.redirect_to('#/users');
         });


### PR DESCRIPTION
**Problem:** While creating a new user, if there is a space at the starting or end of the username, an error is thrown "Invalid argument 'username': Must be lower-case alphanumeric and underscore characters only"

This is unnecessary error, as when adding new users one after the other, spacebar may be pressed at the end of username as natural a natural typing habit. 

**Solution:** Trim the username before submitting the page.