### PR TITLE
added the right DNS config link from the documentation

### DIFF
--- a/app/src/i18n/locales/ar.json
+++ b/app/src/i18n/locales/ar.json
@@ -54,7 +54,7 @@
     "disable": "تعطيل",
     "dns": "خدمة أسماء النطاقات",
     "domain_add": "إضافة نطاق",
-    "domain_add_dns_doc": "… و قد قُمتُ  <a href='//yunohost.org/dns'>بإعداد خدمة أسماء النطاقات بصورة صحيحة</a>.",
+    "domain_add_dns_doc": "… و قد قُمتُ  <a href='//yunohost.org/ar/dns_config'>بإعداد خدمة أسماء النطاقات بصورة صحيحة</a>.",
     "domain_add_dyndns_doc": "... و إني أريد الحصول على خدمة أسماء النطاقات الديناميكي.",
     "domain_add_panel_with_domain": "عندي إسم نطاق …",
     "domain_add_panel_without_domain": "لا أمتلك إسم نطاق …",

--- a/app/src/i18n/locales/ca.json
+++ b/app/src/i18n/locales/ca.json
@@ -55,7 +55,7 @@
     "disable": "Desactivar",
     "dns": "DNS",
     "domain_add": "Afegir domini",
-    "domain_add_dns_doc": "... i he <a href='//yunohost.org/dns'> configurat el meu DNS correctament</a>.",
+    "domain_add_dns_doc": "... i he <a href='//yunohost.org/en/dns_config'> configurat el meu DNS correctament</a>.",
     "domain_add_dyndns_doc": "... i vull uns servei de DNS dinàmic.",
     "domain_add_panel_with_domain": "Ja tinc un nom de domini…",
     "domain_add_panel_without_domain": "No tinc un nom de domini…",

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -35,7 +35,7 @@
     "description": "Beschreibung",
     "disable": "Deaktivieren",
     "domain_add": "Domain hinzufügen",
-    "domain_add_dns_doc": "... und ich habe <a href='//yunohost.org/dns'>meine DNS Einstellung richtig hinterlegt</a>.",
+    "domain_add_dns_doc": "... und ich habe <a href='//yunohost.org/en/dns_config'>meine DNS Einstellung richtig hinterlegt</a>.",
     "domain_add_dyndns_doc": "... und ich möchte einen Dienst für dynamisches DNS nutzen.",
     "domain_add_panel_with_domain": "Ich habe schon eine Domain…",
     "domain_add_panel_without_domain": "Ich habe keine Domain…",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -117,7 +117,7 @@
     "disabled": "Disabled",
     "dns": "DNS",
     "domain_add": "Add domain",
-    "domain_add_dns_doc": "… and I have <a href='//yunohost.org/dns'>set my DNS correctly</a>.",
+    "domain_add_dns_doc": "… and I have <a href='//yunohost.org/en/dns_config'>set my DNS correctly</a>.",
     "domain_add_dyndns_doc": "… and I want a dynamic DNS service.",
     "domain_add_dyndns_forbidden": "You have already subscribed to a DynDNS domain, you can ask to remove your current DynDNS domain on the forum <a href='//forum.yunohost.org/t/nohost-domain-recovery-suppression-de-domaine-en-nohost-me-noho-st-et-ynh-fr/442'>in the dedicated thread</a>.",
     "domain_add_panel_with_domain": "I already have a domain name…",

--- a/app/src/i18n/locales/eo.json
+++ b/app/src/i18n/locales/eo.json
@@ -64,7 +64,7 @@
     "mailbox_quota_placeholder": "Lasu malplenan aŭ agordi al 0 por malaktivigi.",
     "domain_default_desc": "La defaŭlta domajno estas la konekta domajno, kie uzantoj ensalutas.",
     "domain_dns_longdesc": "Vidu DNS-agordon",
-    "domain_add_dns_doc": "... kaj mi <a href='//yunohost.org/dns'> agordis mian DNS ĝuste </a>.",
+    "domain_add_dns_doc": "... kaj mi <a href='//yunohost.org/en/dns_config'> agordis mian DNS ĝuste </a>.",
     "confirm_update_apps": "Ĉu vi certas, ke vi volas ĝisdatigi ĉiujn aplikojn ?",
     "confirm_install_custom_app": "AVERTO! Instali aplikojn de tria partio eble kompromitos la integrecon kaj sekurecon de via sistemo. Vi probable ne devas instali ĝin krom se vi scias kion vi faras. Ĉu vi pretas riski tion?",
     "add": "Aldoni",

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -40,7 +40,7 @@
     "disable": "Inhabilitar",
     "dns": "DNS",
     "domain_add": "Añadir dominio",
-    "domain_add_dns_doc": "... y tengo <a href='//yunohost.org/dns'>mi DNS correctamente configurado</a>.",
+    "domain_add_dns_doc": "... y tengo <a href='//yunohost.org/es/dns_config'>mi DNS correctamente configurado</a>.",
     "domain_add_dyndns_doc": "…y quiero un servicio de DNS dinámico.",
     "domain_add_panel_with_domain": "Ya tengo un nombre de dominio…",
     "domain_add_panel_without_domain": "No tengo un nombre de dominio…",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -40,7 +40,7 @@
     "disable": "Désactiver",
     "dns": "DNS",
     "domain_add": "Ajouter un domaine",
-    "domain_add_dns_doc": "… et j'ai <a href='//yunohost.org/dns'>configuré mes DNS correctement</a>.",
+    "domain_add_dns_doc": "… et j'ai <a href='https://yunohost.org/fr/dns_config'>configuré mes DNS correctement</a>.",
     "domain_add_dyndns_doc": "… et je souhaite ajouter un service DNS dynamique.",
     "domain_add_panel_with_domain": "J'ai déjà un nom de domaine …",
     "domain_add_panel_without_domain": "Je n'ai pas de nom de domaine …",

--- a/app/src/i18n/locales/it.json
+++ b/app/src/i18n/locales/it.json
@@ -29,7 +29,7 @@
     "description": "Descrizione",
     "disable": "Disabilita",
     "domain_add": "Aggiungi dominio",
-    "domain_add_dns_doc": "… e ho <a href='//yunohost.org/dns'>correttamente impostato il mio DNS</a>.",
+    "domain_add_dns_doc": "… e ho <a href='//yunohost.org/en/dns_config'>correttamente impostato il mio DNS</a>.",
     "domain_add_dyndns_doc": "... e voglio un servizio DNS dinamico.",
     "domain_add_panel_with_domain": "Ho già un nome di domino…",
     "domain_add_panel_without_domain": "Non ho un nome di domino…",

--- a/app/src/i18n/locales/nl.json
+++ b/app/src/i18n/locales/nl.json
@@ -35,7 +35,7 @@
     "description": "Beschrijving",
     "disable": "Uitschakelen",
     "domain_add": "Domeinnaam toevoegen",
-    "domain_add_dns_doc": "... en ik heb <a href='//yunohost.org/dns'>mijn DNS correct ingesteld</a>.",
+    "domain_add_dns_doc": "... en ik heb <a href='//yunohost.org/en/dns_config'>mijn DNS correct ingesteld</a>.",
     "domain_add_dyndns_doc": "... en ik wil een dynamische DNS-dienst (Dynamic DNS).",
     "domain_add_panel_with_domain": "Ik heb al een domeinnaam…",
     "domain_add_panel_without_domain": "Ik heb nog geen domeinnaam…",

--- a/app/src/i18n/locales/oc.json
+++ b/app/src/i18n/locales/oc.json
@@ -54,7 +54,7 @@
     "disable": "Desactivar",
     "dns": "DNS",
     "domain_add": "Ajustar un domeni",
-    "domain_add_dns_doc": "… e ai <a href='//yunohost.org/dns'>>corrèctament configurat mos DNS</a>.",
+    "domain_add_dns_doc": "… e ai <a href='//yunohost.org/en/dns_config'>>corrèctament configurat mos DNS</a>.",
     "domain_add_dyndns_doc": "… e desiri un nom de domeni preconfigurat.",
     "domain_add_panel_with_domain": "Ai ja mon nom de domeni…",
     "domain_add_panel_without_domain": "Ai pas de nom de domeni…",

--- a/app/src/i18n/locales/pt.json
+++ b/app/src/i18n/locales/pt.json
@@ -23,7 +23,7 @@
     "description": "Descrição",
     "disable": "Desativar",
     "domain_add": "Adicionar domínio",
-    "domain_add_dns_doc": "… coloco <a href='//yunohost.org/dns'>para definir o meu DNS</a>.",
+    "domain_add_dns_doc": "… coloco <a href='//yunohost.org/en/dns_config'>para definir o meu DNS</a>.",
     "domain_add_dyndns_doc": "... quero um serviço DNS dinâmico.",
     "domain_add_panel_with_domain": "Já tenho um domínio registado…",
     "domain_add_panel_without_domain": "Ainda não registei um domínio…",

--- a/app/src/i18n/locales/ru.json
+++ b/app/src/i18n/locales/ru.json
@@ -138,7 +138,7 @@
     "manually_renew_letsencrypt_message": "Сертификат будет автоматически обновлён в последние 15 дней своего действия. Вы может вручную обновить его, если хотите. (Не рекомендуется).",
     "manually_renew_letsencrypt": "Теперь обновить вручную",
     "confirm_postinstall": "Вы начинаете процесс конфигурации домена {domain}. Это займёт несколько минут, *не прерывайте процесс*.",
-    "domain_add_dns_doc": "… я <a href='//yunohost.org/dns'>set my DNS установил мой DNS правильно</a>.",
+    "domain_add_dns_doc": "… я <a href='//yunohost.org/en/dns_config'>set my DNS установил мой DNS правильно</a>.",
     "tools": "Инструменты",
     "tools_adminpw": "Смените пароль администратора",
     "tools_adminpw_current": "Действующий пароль",

--- a/app/src/i18n/locales/sv.json
+++ b/app/src/i18n/locales/sv.json
@@ -73,7 +73,7 @@
     "logs_path": "Sökväg",
     "add": "Lägg till",
     "install_name": "Installera {id}",
-    "domain_add_dns_doc": "… och jag har <a href='//yunohost.org/dns'>konfigurerat min DNS korrekt</a>.",
+    "domain_add_dns_doc": "… och jag har <a href='//yunohost.org/en/dns_config'>konfigurerat min DNS korrekt</a>.",
     "error_server_unexpected": "Oväntat serverfel",
     "previous": "Föregående",
     "save": "Spara",


### PR DESCRIPTION
I was fiddling with yunohost here and saw that the link in the Domain set up flow was wrong. I took the liberty to fix it and this PR is the fix for all languages. Most languages are not translated but some are (fr, en, es for example)

Hope this helps!

Cheers!