### PR TITLE
stretch: Add obsolete disclaimer on home page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -227,6 +227,7 @@
     "logs_context": "Context",
     "logs_share_with_yunopaste": "Share with YunoPaste",
     "logs_more": "Display more lines",
+    "obsolete_version": "You are running an obsolete version of YunoHost. The YunoHost team highly recommend to run the migration to YunoHost 4.x / Buster available in Tools > Migrations. More information can be found on <a href='https://yunohost.org/stretch_buster_migration'>this page in the documentation</a>",
     "path_url": "Path",
     "pending_migrations": "There are some pending migrations waiting to be ran. Please go to the <a href='#/tools/migrations'>Tools > Migrations</a> view to run them.",
     "port": "Port",

--- a/src/views/home.ms
+++ b/src/views/home.ms
@@ -1,3 +1,7 @@
+<p class="alert alert-warning">
+{{t 'obsolete_version' }}
+</p>
+
 <div class="list-group">
     <a href="#/users" class="list-group-item slide clearfix">
         <span class="pull-right fa-chevron-right"></span>


### PR DESCRIPTION
We're in April 2021, Buster was released in June/July 20**19**, Yunohost 4.x in June/July 2020.