### PR TITLE
Fix postinstall validation errors and add --force-diskspace admin equivalent

### DIFF
--- a/app/src/api/errors.js
+++ b/app/src/api/errors.js
@@ -47,6 +47,7 @@ class APIBadRequestError extends APIError {
   constructor (method, response, errorData) {
     super(method, response, errorData)
     this.name = 'APIBadRequestError'
+    this.key = errorData.error_key
   }
 }
 

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -10,7 +10,10 @@
         <slot name="default" />
 
         <slot name="server-error">
-          <b-alert variant="danger" :show="serverError !== ''" v-html="serverError" />
+          <b-alert
+            variant="danger" class="my-3"
+            :show="serverError !== ''" v-html="serverError"
+          />
         </slot>
       </b-form>
     </template>

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -314,6 +314,9 @@
     "permission_show_tile_enabled": "Visible as tile in user portal",
     "port": "Port",
     "ports": "Ports",
+    "postinstall": {
+        "force": "Force the post-install"
+    },
     "postinstall_domain": "This is the first domain name linked to your YunoHost server, but also the one which will be used by your server's users to access the authentication portal. Accordingly, it will be visible by everyone, so choose it carefully.",
     "postinstall_intro_1": "Congratulations! YunoHost has been successfully installed.",
     "postinstall_intro_2": "Two more configuration steps are required to activate you server's services.",

--- a/app/src/views/Login.vue
+++ b/app/src/views/Login.vue
@@ -32,9 +32,13 @@
 export default {
   name: 'Login',
 
+  props: {
+    skipInstallCheck: { type: Boolean, default: false }
+  },
+
   data () {
     return {
-      disabled: true,
+      disabled: !this.skipInstallCheck,
       password: '',
       isValid: null,
       apiError: undefined
@@ -51,6 +55,7 @@ export default {
   },
 
   created () {
+    if (this.skipInstallCheck) return
     this.$store.dispatch('CHECK_INSTALL').then(installed => {
       if (installed) {
         this.disabled = false

--- a/app/src/views/PostInstall.vue
+++ b/app/src/views/PostInstall.vue
@@ -12,35 +12,55 @@
         <span v-html="$t('postinstall_intro_3')" />
       </p>
 
-      <b-button size="lg" variant="primary" @click="step = 'domain'">
+      <b-button size="lg" variant="primary" @click="goToStep('domain')">
         {{ $t('begin') }}
       </b-button>
     </template>
 
     <!-- DOMAIN SETUP STEP -->
     <template v-else-if="step === 'domain'">
-      <domain-form @submit="setDomain" :title="$t('postinstall_set_domain')" :submit-text="$t('next')">
+      <domain-form
+        :title="$t('postinstall_set_domain')" :submit-text="$t('next')" :server-error="serverError"
+        @submit="setDomain"
+      >
         <template #disclaimer>
           <p class="alert alert-info" v-t="'postinstall_domain'" />
         </template>
       </domain-form>
 
-      <b-button variant="primary" @click="step = 'start'" class="mt-3">
+      <b-button variant="primary" @click="goToStep('start')" class="mt-3">
         <icon iname="chevron-left" /> {{ $t('previous') }}
       </b-button>
     </template>
 
     <!-- PASSWORD SETUP STEP -->
     <template v-else-if="step === 'password'">
-      <password-form :title="$t('postinstall_set_password')" :submit-text="$t('next')" @submit="setPassword">
+      <password-form
+        :title="$t('postinstall_set_password')" :submit-text="$t('next')" :server-error="serverError"
+        @submit="setPassword"
+      >
         <template #disclaimer>
           <p class="alert alert-warning" v-t="'postinstall_password'" />
         </template>
       </password-form>
 
-      <b-button variant="primary" @click="step = 'domain'" class="mt-3">
+      <b-button variant="primary" @click="goToStep('domain')" class="mt-3">
         <icon iname="chevron-left" /> {{ $t('previous') }}
       </b-button>
+    </template>
+
+    <template v-else-if="step === 'rootfsspace-error'">
+      <card no-body header-class="d-none" footer-bg-variant="danger">
+        <b-card-body class="alert alert-danger m-0">
+          {{ serverError }}
+        </b-card-body>
+
+        <template #buttons>
+          <b-button variant="light" size="sm" @click="performPostInstall(true)">
+            <icon iname="warning" /> {{ $t('postinstall.force') }}
+          </b-button>
+        </template>
+      </card>
     </template>
 
     <!-- POST-INSTALL SUCCESS STEP -->
@@ -71,14 +91,20 @@ export default {
     return {
       step: 'start',
       domain: undefined,
-      password: undefined
+      password: undefined,
+      serverError: ''
     }
   },
 
   methods: {
+    goToStep (step) {
+      this.serverError = ''
+      this.step = step
+    },
+
     setDomain ({ domain }) {
       this.domain = domain
-      this.step = 'password'
+      this.goToStep('password')
     },
 
     async setPassword ({ password }) {
@@ -90,11 +116,23 @@ export default {
       this.performPostInstall()
     },
 
-    performPostInstall () {
+    performPostInstall (force = false) {
       // FIXME does the api will throw an error for bad passwords ?
-      api.post('postinstall', { domain: this.domain, password: this.password }).then(data => {
+      api.post('postinstall' + (force ? '?force_diskspace' : ''), { domain: this.domain, password: this.password }).then(data => {
         // Display success message and allow the user to login
-        this.step = 'login'
+        this.goToStep('login')
+      }).catch(err => {
+        if (err.name !== 'APIBadRequestError') throw err
+        if (err.key === 'postinstall_low_rootfsspace') {
+          this.step = 'rootfsspace-error'
+        } else if (err.key.includes('password')) {
+          this.step = 'password'
+        } else if (['domain', 'dyndns'].some(word => err.key.includes(word))) {
+          this.step = 'domain'
+        } else {
+          throw err
+        }
+        this.serverError = err.message
       })
     }
   },

--- a/app/src/views/PostInstall.vue
+++ b/app/src/views/PostInstall.vue
@@ -48,7 +48,7 @@
       <p class="alert alert-success">
         <icon iname="thumbs-up" /> {{ $t('installation_complete') }}
       </p>
-      <login />
+      <login skip-install-check />
     </template>
   </div>
 </template>

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -61,9 +61,7 @@ export default {
   props: {
     title: { type: String, required: true },
     submitText: { type: String, default: null },
-    serverError: { type: String, default: '' },
-    // Do not query the api (used by postinstall)
-    noStore: { type: Boolean, default: false }
+    serverError: { type: String, default: '' }
   },
 
   data () {


### PR DESCRIPTION
Display form validation errors in their respective cards (with auto redirection to the step involved)
Also handle the special case where someone has not enough diskspace (a new card with an error and a button to run the postinstall with `--force-diskspace`)

Should fix https://github.com/YunoHost/issues/issues/1697

## PR STATUS
Tested on my side but on a already installed system

## HOW TO TEST

run the postinstall with some mistakes in every fields (test.nohost.me in domain for example, a weak password, etc)  
If you can, edit https://github.com/YunoHost/yunohost/blob/dev/src/yunohost/tools.py#L304 by replacing the 10 gb limit with 20 or whatever that would trigger the error on your setup.  