### PR TITLE
Add missing translations

### DIFF
--- a/app/vue.config.js
+++ b/app/vue.config.js
@@ -11,7 +11,9 @@ const dateFnsLocales = [
   'eo',
   'es',
   'eu',
+  'fi',
   'fr', // for 'fr' & 'br'
+  'gl',
   'hi',
   'hu',
   'it',
@@ -23,6 +25,7 @@ const dateFnsLocales = [
   'ru',
   'sv',
   'tr',
+  'uk',
   'zh_CN' // for 'zh_Hans'
 ]
 

--- a/app/vue.config.js
+++ b/app/vue.config.js
@@ -11,6 +11,7 @@ const dateFnsLocales = [
   'eo',
   'es',
   'eu',
+  'fa',
   'fi',
   'fr', // for 'fr' & 'br'
   'gl',


### PR DESCRIPTION
## Problem
- Some language are missing from the language list in webadmin / Outils / Paramètres de l'administration web .

Following a private message in the forum  concerning the translation into Galician (gl) not beeing integrated into the project, I just notice that some of the translations files where not fetch... I don't know if it is the right way to integrate them... I guess we also could add Persian (fa) to the list.
