### PR TITLE
Resolve app install interface blank when app manifest argument is missing "ask" value

### DIFF
--- a/app/src/helpers/yunohostArguments.js
+++ b/app/src/helpers/yunohostArguments.js
@@ -8,13 +8,13 @@ import { isObjectLiteral, isEmptyValue, flattenObjectLiteral } from '@/helpers/c
  * Tries to find a translation corresponding to the user's locale/fallback locale in a
  * Yunohost argument or simply return the string if it's not an object literal.
  *
- * @param {(Object|String)} field - A field value containing a translation object or string
+ * @param {(Object|String|undefined)} field - A field value containing a translation object or string
  * @return {String}
  */
 export function formatI18nField (field) {
   if (typeof field === 'string') return field
   const { locale, fallbackLocale } = store.state
-  return field[locale] || field[fallbackLocale] || field.en
+  return field ? field[locale] || field[fallbackLocale] || field.en : ''
 }
 
 


### PR DESCRIPTION
### Describe the bug

The webadmin fails to display the app install page if an app manifest arguments is missing the "ask" key of custom arguments.

### Context

- YunoHost version: 4.2.8.3 (don't have a dev environment at the moment to test it there)

### Steps to reproduce

- Try to install an app, from the webadmin, with a manifest's arguments without "ask" field
- The webadmin just shows an [empty blank page](https://forum.yunohost.org/uploads/default/original/2X/6/6e82432da21abd6fe26edf91cb61f7581eaac18d.png)

### Proposed solution

I'm not able to test this code, so it's just a concept. Could be that I missed something and it doesn't resolve the issue. But following the error trace in the browser, it probably comes from [here](https://github.com/YunoHost/yunohost-admin/blob/64ae24facd52a91c492e2a5ca058f43a505a1ff7/app/src/helpers/yunohostArguments.js#L61-L67).
