### PR TITLE
Optimization for waiting modal messages and AppCatalog cards rendering

### DIFF
--- a/app/src/components/LazyRenderer.vue
+++ b/app/src/components/LazyRenderer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="lazy-renderer" :style="`min-height: ${fixedMinHeight}px`">
+    <slot v-if="render" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'LazyRenderer',
+
+  props: {
+    unrender: { type: Boolean, default: true },
+    minHeight: { type: Number, default: 0 },
+    renderDelay: { type: Number, default: 100 },
+    unrenderDelay: { type: Number, default: 2000 },
+    rootMargin: { type: String, default: '300px' }
+  },
+
+  data () {
+    return {
+      observer: null,
+      render: false,
+      fixedMinHeight: this.minHeight
+    }
+  },
+
+  mounted () {
+    let unrenderTimer
+    let renderTimer
+    this.observer = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        clearTimeout(unrenderTimer)
+        // Show the component after a delay (to avoid rendering while scrolling fast)
+        renderTimer = setTimeout(() => {
+          this.render = true
+        }, this.unrender ? this.renderDelay : 0)
+
+        if (!this.unrender) {
+          // Stop listening to intersections after first appearance if unrendering is not activated
+          this.observer.disconnect()
+        }
+      } else if (this.unrender) {
+        clearTimeout(renderTimer)
+        // Hide the component after a delay if it's no longer in the viewport
+        unrenderTimer = setTimeout(() => {
+          this.fixedMinHeight = this.$el.clientHeight
+          this.render = false
+        }, this.unrenderDelay)
+      }
+    }, { rootMargin: this.rootMargin })
+
+    this.observer.observe(this.$el)
+  },
+
+  beforeDestroy () {
+    this.observer.disconnect()
+  }
+}
+</script>

--- a/app/src/components/MessageListGroup.vue
+++ b/app/src/components/MessageListGroup.vue
@@ -1,9 +1,15 @@
 <template>
   <b-list-group
-    v-bind="$attrs" ref="self"
-    flush :class="{ 'fixed-height': fixedHeight, 'bordered': bordered }"
+    v-bind="$attrs" flush
+    :class="{ 'fixed-height': fixedHeight, 'bordered': bordered }"
+    @scroll="onScroll"
   >
-    <b-list-group-item v-for="({ color, text }, i) in messages" :key="i">
+    <b-list-group-item
+      v-if="limit && messages.length > limit"
+      variant="info" v-t="'api.partial_logs'"
+    />
+
+    <b-list-group-item v-for="({ color, text }, i) in reducedMessages" :key="i">
       <span class="status" :class="'bg-' + color" />
       <span v-html="text" />
     </b-list-group-item>
@@ -18,15 +24,36 @@ export default {
     messages: { type: Array, required: true },
     fixedHeight: { type: Boolean, default: false },
     bordered: { type: Boolean, default: false },
-    autoScroll: { type: Boolean, default: false }
+    autoScroll: { type: Boolean, default: false },
+    limit: { type: Number, default: null }
+  },
+
+  data () {
+    return {
+      auto: true
+    }
+  },
+
+  computed: {
+    reducedMessages () {
+      const len = this.messages.length
+      if (!this.limit || len <= this.limit) {
+        return this.messages
+      }
+      return this.messages.slice(len - this.limit)
+    }
   },
 
   methods: {
     scrollToEnd () {
+      if (!this.auto) return
       this.$nextTick(() => {
-        const container = this.$refs.self
-        container.scrollTo(0, container.lastElementChild.offsetTop)
+        this.$el.scrollTo(0, this.$el.lastElementChild.offsetTop)
       })
+    },
+
+    onScroll ({ target }) {
+      this.auto = target.scrollHeight === target.scrollTop + target.clientHeight
     }
   },
 

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -14,6 +14,7 @@
     "administration_password": "Administration password",
     "all": "All",
     "api": {
+        "partial_logs": "[...] (check in history for full logs)",
         "processing": "The server is processing the action...",
         "query_status": {
             "error": "Unsuccessful",

--- a/app/src/views/_partials/HistoryConsole.vue
+++ b/app/src/views/_partials/HistoryConsole.vue
@@ -59,7 +59,7 @@
             @shown="scrollToAction(i)"
             @hide="scrollToAction(i)"
           >
-            <message-list-group :messages="action.messages" flush />
+            <message-list-group :messages="action.messages" />
           </b-collapse>
         </b-card>
       </div>

--- a/app/src/views/_partials/WaitingDisplay.vue
+++ b/app/src/views/_partials/WaitingDisplay.vue
@@ -18,6 +18,7 @@
     <message-list-group
       v-if="hasMessages" :messages="request.messages"
       bordered fixed-height auto-scroll
+      :limit="100"
     />
   </b-card-body>
 </template>

--- a/app/src/views/app/AppCatalog.vue
+++ b/app/src/views/app/AppCatalog.vue
@@ -64,52 +64,56 @@
 
     <!-- APPS CARDS -->
     <b-card-group v-else deck>
-      <b-card no-body v-for="app in filteredApps" :key="app.id">
-        <b-card-body class="d-flex flex-column">
-          <b-card-title class="d-flex mb-2">
-            {{ app.manifest.name }}
-            <small v-if="app.state !== 'working'" class="d-flex align-items-center ml-2">
-              <b-badge
-                v-if="app.state !== 'highquality'"
-                :variant="(app.color === 'danger' && app.state === 'lowquality') ? 'warning' : app.color"
-                v-b-popover.hover.bottom="$t(`app_state_${app.state}_explanation`)"
-              >
-                {{ $t('app_state_' + app.state) }}
-              </b-badge>
-              <icon
-                v-else iname="star" class="star"
-                v-b-popover.hover.bottom="$t(`app_state_${app.state}_explanation`)"
-              />
-            </small>
-          </b-card-title>
+      <lazy-renderer v-for="app in filteredApps" :key="app.id" :min-height="120">
+        <b-card no-body>
+          <b-card-body class="d-flex flex-column">
+            <b-card-title class="d-flex mb-2">
+              {{ app.manifest.name }}
 
-          <b-card-text>{{ app.manifest.description }}</b-card-text>
+              <small v-if="app.state !== 'working'" class="d-flex align-items-center ml-2">
+                <b-badge
+                  v-if="app.state !== 'highquality'"
+                  :variant="(app.color === 'danger' && app.state === 'lowquality') ? 'warning' : app.color"
+                  v-b-popover.hover.bottom="$t(`app_state_${app.state}_explanation`)"
+                >
+                  {{ $t('app_state_' + app.state) }}
+                </b-badge>
 
-          <b-card-text v-if="app.maintained === 'orphaned'" class="align-self-end mt-auto">
-            <span class="alert-warning p-1" v-b-popover.hover.top="$t('orphaned_details')">
-              <icon iname="warning" /> {{ $t(app.maintained) }}
-            </span>
-          </b-card-text>
-        </b-card-body>
+                <icon
+                  v-else iname="star" class="star"
+                  v-b-popover.hover.bottom="$t(`app_state_${app.state}_explanation`)"
+                />
+              </small>
+            </b-card-title>
 
-        <!-- APP BUTTONS -->
-        <b-button-group>
-          <b-button :href="app.git.url" variant="outline-dark" target="_blank">
-            <icon iname="code" /> {{ $t('code') }}
-          </b-button>
+            <b-card-text>{{ app.manifest.description }}</b-card-text>
 
-          <b-button :href="app.git.url + '/blob/master/README.md'" variant="outline-dark" target="_blank">
-            <icon iname="book" /> {{ $t('readme') }}
-          </b-button>
+            <b-card-text v-if="app.maintained === 'orphaned'" class="align-self-end mt-auto">
+              <span class="alert-warning p-1" v-b-popover.hover.top="$t('orphaned_details')">
+                <icon iname="warning" /> {{ $t(app.maintained) }}
+              </span>
+            </b-card-text>
+          </b-card-body>
 
-          <b-button v-if="app.isInstallable" :variant="app.color" @click="onInstallClick(app)">
-            <icon iname="plus" /> {{ $t('install') }} <icon v-if="app.color === 'danger'" class="ml-1" iname="warning" />
-          </b-button>
-          <b-button v-else :variant="app.color" disabled>
-            {{ $t('installed') }}
-          </b-button>
-        </b-button-group>
-      </b-card>
+          <!-- APP BUTTONS -->
+          <b-button-group>
+            <b-button :href="app.git.url" variant="outline-dark" target="_blank">
+              <icon iname="code" /> {{ $t('code') }}
+            </b-button>
+
+            <b-button :href="app.git.url + '/blob/master/README.md'" variant="outline-dark" target="_blank">
+              <icon iname="book" /> {{ $t('readme') }}
+            </b-button>
+
+            <b-button v-if="app.isInstallable" :variant="app.color" @click="onInstallClick(app)">
+              <icon iname="plus" /> {{ $t('install') }} <icon v-if="app.color === 'danger'" class="ml-1" iname="warning" />
+            </b-button>
+            <b-button v-else :variant="app.color" disabled>
+              {{ $t('installed') }}
+            </b-button>
+          </b-button-group>
+        </b-card>
+      </lazy-renderer>
     </b-card-group>
 
     <template #bot>
@@ -155,11 +159,16 @@
 <script>
 import { validationMixin } from 'vuelidate'
 
+import LazyRenderer from '@/components/LazyRenderer'
 import { required, githubLink } from '@/helpers/validators'
 import { randint } from '@/helpers/commons'
 
 export default {
   name: 'AppCatalog',
+
+  components: {
+    LazyRenderer
+  },
 
   data () {
     return {
@@ -375,10 +384,11 @@ export default {
 }
 
 .card-deck {
-  .card {
-    border-color: $gray-400;
+  > * {
+    margin-left: 15px;
+    margin-right: 15px;
     margin-bottom: 2rem;
-    flex-basis: 90%;
+    flex-basis: 100%;
     @include media-breakpoint-up(md) {
       flex-basis: 50%;
       max-width: calc(50% - 30px);
@@ -387,6 +397,15 @@ export default {
       flex-basis: 33%;
       max-width: calc(33.3% - 30px);
     }
+
+    .card {
+      margin: 0;
+      height: 100%;
+    }
+  }
+
+  .card {
+    border-color: $gray-400;
 
     // not maintained info
     .alert-warning {
@@ -402,6 +421,8 @@ export default {
     @include media-breakpoint-up(sm) {
       min-height: 10rem;
     }
+
+    flex-basis: 90%;
     border: 0;
 
     .btn {


### PR DESCRIPTION
First commit should fix lags while running quite verbose actions (like upgrade).
The waiting modal will only display 100 messages at a time (users can still go to history to see the full logs), and websocket messages are handle by batches of 50ms instead of constant stream which was triggering way too much repaint cycles.

You can test it by running the api in debug (`yunohost-api --debug`) and adding a new domain from the web admin for example (quite verbose action in debug, about 1000 ws messages)

Also added a new component that act like a viewport observer that will only render its given component if it is in the viewport (lazy rendering). This should fix lags in the app catalog first load and while searching.