### PR TITLE
[enh] Support github-independent repo urls and/or pointing to specific branches

### DIFF
--- a/app/src/helpers/validators/customValidators.js
+++ b/app/src/helpers/validators/customValidators.js
@@ -34,7 +34,7 @@ const emailForward = value => helpers.withParams(
   }
 )(value)
 
-const githubLink = helpers.regex('githubLink', /^https:\/\/github.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+[/]?$/)
+const appRepoUrl = helpers.regex('appRepoUrl', /^https:\/\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_./]+\/[a-zA-Z0-9-_.]+_ynh(\/?(-\/)?tree\/[a-zA-Z0-9-_]+)?(\.git)?\/?$/)
 
 const includes = items => item => helpers.withParams(
   { type: 'includes', value: item },
@@ -56,7 +56,7 @@ export {
   emailForward,
   emailForwardLocalPart,
   emailLocalPart,
-  githubLink,
+  appRepoUrl,
   includes,
   name,
   unique

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -194,7 +194,7 @@
         "dynDomain": "Invalid domain name: Must be lower-case alphanumeric and dash characters only",
         "email": "Invalid email: must be alphanumeric and <code>_.-</code> characters only (e.g. someone@example.com, s0me-1@example.com)",
         "emailForward": "Invalid email forward: must be alphanumeric and <code>_.-+</code> characters only (e.g. someone+tag@example.com, s0me-1+tag@example.com)",
-        "githubLink": "URL must be a valid GitHub link to a repository",
+        "appRepoUrl": "YunoHost app repository URLs are expected to look like https://domain.tld/path/to/repo_ynh",
         "name": "Names may not includes special characters except <code> ,.'-</code>",
         "minValue": "Value must be a number equal or greater than {min}.",
         "maxValue": "Value must be a number equal or lesser than {max}.",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -374,7 +374,7 @@
         "notInUsers": "L'utilisateur '{value}' existe déjà.",
         "minValue": "La valeur doit être un nombre égal ou supérieur à {min}.",
         "name": "Les noms ne peuvent pas comporter de caractères spéciaux, sauf <code> ,.'-</code>",
-        "githubLink": "L'URL doit être un lien GitHub valide vers un dépôt",
+        "appRepoUrl": "Les URLs de dêpôt d'app YunoHost doivent ressembler à https://domain.tld/path/to/repo_ynh",
         "emailForward": "Adresse de transfert de courrier électronique invalide : elle doit être composée de caractères alphanumérique et de <code>_.-+</code> seulement (par exemple, someone+tag@example.com, s0me-1+tag@example.com)",
         "email": "Adresse de courriel invalide : elle doit être composée de caractères alphanumérique et des caractères <code>_.-</code> seulement (par exemple someone@example.com, s0me-1@example.com)",
         "dynDomain": "Nom de domaine invalide : Il doit être composé de minuscules alphanumériques et de tirets uniquement",

--- a/app/src/views/app/AppCatalog.vue
+++ b/app/src/views/app/AppCatalog.vue
@@ -155,7 +155,7 @@
 <script>
 import { validationMixin } from 'vuelidate'
 
-import { required, githubLink } from '@/helpers/validators'
+import { required, appRepoUrl } from '@/helpers/validators'
 import { randint } from '@/helpers/commons'
 
 export default {
@@ -249,7 +249,7 @@ export default {
 
   validations: {
     customInstall: {
-      url: { required, githubLink }
+      url: { required, appRepoUrl }
     }
   },
 


### PR DESCRIPTION

Fix https://github.com/YunoHost/issues/issues/1653 and https://github.com/YunoHost/issues/issues/1901

The following urls should be supported, c.f. independent pending PR in the core : https://github.com/YunoHost/yunohost/blob/171b3b25d9d4cb7aad8b2cbbc5aeb7eee6243a1f/src/yunohost/tests/test_appurl.py#L31