### PR TITLE
ugly fix LazyRenderer bug

### DIFF
--- a/app/src/components/LazyRenderer.vue
+++ b/app/src/components/LazyRenderer.vue
@@ -27,8 +27,19 @@ export default {
   mounted () {
     let unrenderTimer
     let renderTimer
+
     this.observer = new IntersectionObserver(entries => {
-      if (entries[0].isIntersecting) {
+      let intersecting = entries[0].isIntersecting
+
+      // Fix for weird bug when typing fast in app search or on slow client.
+      // Intersection is triggered but even if the element is indeed in the viewport,
+      // isIntersecting is `false`, so we have to manually check this…
+      // FIXME Would be great to find out why this is happening
+      if (!intersecting && this.$el.offsetTop < window.innerHeight) {
+        intersecting = true
+      }
+
+      if (intersecting) {
         clearTimeout(unrenderTimer)
         // Show the component after a delay (to avoid rendering while scrolling fast)
         renderTimer = setTimeout(() => {


### PR DESCRIPTION
# Bug

Some users experiencing a weird bug where app cards in the app catalog are not showing up while searching.
It looks like the intersectionObserver on the LazyRenderer component is triggered but it says it's not intersecting (maybe because of concurency timing stuff where the check is made before some card are removed and the hook is executed after those are removed idk).

# Solution

Add an ugly check on the LazyRenderer component intersection hook to be sure the element is really not in the viewport.