### PR TITLE
[enh] add --purge option in app uninstall modal

### DIFF
--- a/app/src/helpers/yunohostArguments.js
+++ b/app/src/helpers/yunohostArguments.js
@@ -89,7 +89,7 @@ export function formatYunoHostArgument (arg) {
       props: defaultProps.concat(['type', 'autocomplete', 'trim']),
       callback: function () {
         if (!arg.help) {
-          arg.help = 'good_practices_about_admin_password'
+          arg.help = i18n.t('good_practices_about_admin_password')
         }
         arg.example = '••••••••••••'
         validation.passwordLenght = validators.minLength(8)

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -359,6 +359,7 @@
     "postinstall_set_password": "Set administration password",
     "previous": "Previous",
     "protocol": "Protocol",
+    "purge_app_data_checkbox": "Remove the data directory associated with the app (this is usually data you uploaded yourself using the app).",
     "readme": "Readme",
     "rerun_diagnosis": "Rerun diagnosis",
     "restore": "Restore",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -571,5 +571,6 @@
     "domain_dns_push_failed_to_authenticate": "Échec de l'authentification sur l'API du registraire. Très probablement les <a href='#/domains/{domain}/config'>informations d'identification</a> sont incorrectes ? (Erreur : {error})",
     "domain_dns_push_managed_in_parent_domain": "La fonctionnalité d'enregistrement DNS automatique est gérée dans le domaine parent <a href='#/domains/{parent_domain}/dns'>{parent_domain}</a>.",
     "domain_dns_push_not_applicable": "La fonctionnalité d'enregistrements DNS automatiques n'est pas applicable au domaine {domain},<br> Vous devez configurer manuellement vos enregistrements DNS en suivant la <a href='https://yunohost.org/dns'>documentation</a> et les suggestions configuration ci-dessous.",
-    "text_selection_is_disabled": "La sélection du texte est désactivée. Si vous voulez partager ce log *complet*, vous pouvez le faire en cliquant sur le bouton 'Partager avec Yunopaste'.<br/><small>Ou, si vous voulez vraiment vraiment sélectionner du texte, appuyez sur ces touches : ↓↓↑↑.</small>"
+    "text_selection_is_disabled": "La sélection du texte est désactivée. Si vous voulez partager ce log *complet*, vous pouvez le faire en cliquant sur le bouton 'Partager avec Yunopaste'.<br/><small>Ou, si vous voulez vraiment vraiment sélectionner du texte, appuyez sur ces touches : ↓↓↑↑.</small>",
+    "purge_app_data_checkbox": "Supprimer le dossier de données associé à l'app (il s'agit généralement de données téléversées par vous-même via l'app)."
 }

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -131,7 +131,7 @@
         :label="$t('app_info_uninstall_desc')" label-for="uninstall"
         label-class="font-weight-bold" label-cols-md="4"
       >
-        <b-button @click="uninstall" id="uninstall" variant="danger">
+        <b-button v-b-modal.uninstall-modal id="uninstall" variant="danger">
           <icon iname="trash-o" /> {{ $t('uninstall') }}
         </b-button>
       </b-form-group>
@@ -149,6 +149,18 @@
         </b-button>
       </b-form-group>
     </card>
+
+    <b-modal
+      id="uninstall-modal" :title="$t('confirm_uninstall', { name: id })"
+      header-bg-variant="warning" :body-class="{ 'd-none': purge === null }" body-bg-variant=""
+      @ok="uninstall"
+    >
+      <b-form-group v-if="purge !== null">
+        <b-form-checkbox v-model="purge">
+          {{ $t('purge_app_data_checkbox', { name: id }) }}
+        </b-form-checkbox>
+      </b-form-group>
+    </b-modal>
 
     <template #skeleton>
       <card-info-skeleton :item-count="8" />
@@ -182,7 +194,8 @@ export default {
       ],
       infos: undefined,
       app: undefined,
-      form: undefined
+      form: undefined,
+      purge: null
     }
   },
 
@@ -254,6 +267,7 @@ export default {
         supports_config_panel: app.supports_config_panel,
         permissions
       }
+      this.purge = app.support_purge ? false : null
     },
 
     changeLabel (permName, data) {
@@ -289,12 +303,8 @@ export default {
     },
 
     async uninstall () {
-      const confirmed = await this.$askConfirmation(
-        this.$i18n.t('confirm_uninstall', { name: this.id })
-      )
-      if (!confirmed) return
-
-      api.delete('apps/' + this.id, {}, { key: 'apps.uninstall', name: this.infos.label }).then(() => {
+      const data = this.purge ? { purge: '' } : {}
+      api.delete('apps/' + this.id, data, { key: 'apps.uninstall', name: this.infos.label }).then(() => {
         this.$router.push({ name: 'app-list' })
       })
     }


### PR DESCRIPTION
Display a checkbox to purge the datadir if the app has `support_purge: true`
Should fix https://github.com/YunoHost/issues/issues/1854

![image](https://user-images.githubusercontent.com/5127669/140521012-42dc04dd-0b87-4a78-b3ca-bcb2f4c2f9df.png)

Also fix `good_practices_about_admin_password` not being translated in forms.