### PR TITLE
fix '\n' replace with replaceAll

### DIFF
--- a/app/src/api/errors.js
+++ b/app/src/api/errors.js
@@ -8,7 +8,7 @@ import i18n from '@/i18n'
 
 class APIError extends Error {
   constructor (request, { url, status, statusText }, { error }) {
-    super(error ? error.replace('\n', '<br>') : i18n.t('error_server_unexpected'))
+    super(error ? error.replaceAll('\n', '<br>') : i18n.t('error_server_unexpected'))
     const urlObj = new URL(url)
     this.name = 'APIError'
     this.code = status

--- a/app/src/store/info.js
+++ b/app/src/store/info.js
@@ -199,7 +199,7 @@ export default {
     'DISPATCH_MESSAGE' ({ state, commit, dispatch }, { request, messages }) {
       for (const type in messages) {
         const message = {
-          text: messages[type].replace('\n', '<br>'),
+          text: messages[type].replaceAll('\n', '<br>'),
           color: type === 'error' ? 'danger' : type
         }
         let progressBar = message.text.match(/^\[#*\+*\.*\] > /)

--- a/app/src/views/tool/ToolMigrations.vue
+++ b/app/src/views/tool/ToolMigrations.vue
@@ -104,7 +104,7 @@ export default {
       this.done = done.length ? done.reverse() : null
       pending.forEach(migration => {
         if (migration.disclaimer) {
-          migration.disclaimer = migration.disclaimer.replace('\n', '<br>')
+          migration.disclaimer = migration.disclaimer.replaceAll('\n', '<br>')
           this.$set(this.checked, migration.id, null)
         }
       })


### PR DESCRIPTION
Fix last lgtm.com alerts (that fix the issue where only the first `\n` of a string is replaced by `<br>`)