### PR TITLE
[fix] App install is broken when there's choices and the type is string

### DIFF
--- a/app/src/helpers/yunohostArguments.js
+++ b/app/src/helpers/yunohostArguments.js
@@ -73,7 +73,7 @@ export function formatYunoHostArgument (arg) {
       name: 'InputItem',
       props: defaultProps.concat(['autocomplete', 'trim', 'choices']),
       callback: function () {
-        if (arg.choices && arg.choices.length) {
+        if (arg.choices && Object.keys(arg.choices).length) {
             arg.type = 'select'
             this.name = 'SelectItem'
         }


### PR DESCRIPTION
Yikes! `arg.choices` is not an `Array` anymore!