### PR TITLE
fix dark mode initialization & default to light theme

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -160,7 +160,7 @@ export default {
       this.$store.commit('SET_SPINNER', 'spookycat')
     }
 
-    document.documentElement.setAttribute('dark-theme', localStorage.getItem('theme')) // updates the data-theme attribute
+    document.documentElement.setAttribute('dark-theme', this.theme) // updates the data-theme attribute
   }
 }
 </script>

--- a/app/src/store/settings.js
+++ b/app/src/store/settings.js
@@ -13,7 +13,7 @@ export default {
     fallbackLocale: localStorage.getItem('fallbackLocale'),
     cache: localStorage.getItem('cache') !== 'false',
     transitions: localStorage.getItem('transitions') !== 'false',
-    theme: localStorage.getItem('theme') !== 'false',
+    theme: localStorage.getItem('theme') === 'true',
     experimental: localStorage.getItem('experimental') === 'true',
     spinner: 'pacman',
     supportedLocales: supportedLocales


### PR DESCRIPTION
## Problem
On first initialization, `theme`'s localStorage value is unset leading to a white logo with the default light-mode.

## Solution
Use `theme` settings store value for initial setup and default to light-mode for unset localStorage value.