### PR TITLE
Fix config panel apply with empty `args` + fix config panel init error preventing AppInfo from being displayed

### DIFF
--- a/app/src/components/globals/YunoAlert.vue
+++ b/app/src/components/globals/YunoAlert.vue
@@ -28,6 +28,7 @@ export default {
 
   computed: {
     _icon () {
+      if (this.icon) return this.icon
       return DEFAULT_STATUS_ICON[this.variant]
     }
   }

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -75,7 +75,8 @@
       },
       "info": {
         "forum": "Search or ask the forum!",
-        "problem": "A problem with this app?"
+        "problem": "A problem with this app?",
+        "config_panel_error": "An error prevents the configuration panel from being displayed:"
       },
       "install": {
         "license": "License: {license}",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -76,7 +76,8 @@
       "info": {
         "forum": "Search or ask the forum!",
         "problem": "A problem with this app?",
-        "config_panel_error": "An error prevents the configuration panel from being displayed:"
+        "config_panel_error": "An error prevents the configuration panel from being displayed:",
+        "config_panel_error_please_report": "Please report this error to the YunoHost team to get it fixed!"
       },
       "install": {
         "license": "License: {license}",

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -98,6 +98,7 @@
     >
       <p>{{ $t('app.info.config_panel_error') }}</p>
       <p>{{ config_panel_err }}</p>
+      <p>{{ $t('app.info.config_panel_error_please_report') }}</p>
     </yuno-alert>
 
     <!-- BASIC INFOS -->

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -265,6 +265,7 @@ import api, { objectToParams } from '@/api'
 import { readableDate } from '@/helpers/filters/date'
 import { humanPermissionName } from '@/helpers/filters/human'
 import { required } from '@/helpers/validators'
+import { isEmptyValue } from '@/helpers/commons'
 import {
   formatFormData,
   formatI18nField,
@@ -438,7 +439,7 @@ export default {
         action
           ? `apps/${this.id}/actions/${action}`
           : `apps/${this.id}/config/${id}`,
-        { args: objectToParams(args) },
+        isEmptyValue(args) ? {} : { args: objectToParams(args) },
         { key: `apps.${action ? 'action' : 'update'}_config`, id, name: this.id }
       ).then(() => {
         this.$refs.view.fetchQueries({ triggerLoading: true })


### PR DESCRIPTION
fix what was intended in https://github.com/YunoHost/yunohost/pull/1631
fix https://github.com/YunoHost/issues/issues/2176

If an error occurs while getting the config panel, instead of blocking the view, it now display the error above the config panel section, and the expected config panel section still display common operations.

![config_panel_err](https://user-images.githubusercontent.com/5127669/227525393-675ec26f-96d2-4890-b286-fbac8751c593.png)
