### PR TITLE
POC for new log streaming API

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -81,7 +81,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-
+import { connectSSE } from '@/api/handlers'
 import { HistoryConsole, ViewLockOverlay } from '@/views/_partials'
 
 export default {
@@ -118,6 +118,7 @@ export default {
     // state will be automaticly reseted and user will be prompt with the login view.
     if (this.connected) {
       this.$store.dispatch('GET_YUNOHOST_INFOS')
+      connectSSE()
     }
   },
 

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -81,7 +81,6 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { connectSSE } from '@/api/handlers'
 import { HistoryConsole, ViewLockOverlay } from '@/views/_partials'
 
 export default {
@@ -118,7 +117,7 @@ export default {
     // state will be automaticly reseted and user will be prompt with the login view.
     if (this.connected) {
       this.$store.dispatch('GET_YUNOHOST_INFOS')
-      connectSSE()
+      this.$store.dispatch('SSE_CONNECT')
     }
   },
 

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -85,12 +85,9 @@ export default {
     humanKey = null,
     { wait = true, websocket = true, initial = false, asFormData = false } = {}
   ) {
+    // FIXME remove websocket mentions
     // `await` because Vuex actions returns promises by default.
     const request = await store.dispatch('INIT_REQUEST', { method, uri, humanKey, initial, wait, websocket })
-
-    if (websocket) {
-      await openWebSocket(request)
-    }
 
     let options = this.options
     if (method === 'GET') {

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -4,7 +4,7 @@
  */
 
 import store from '@/store'
-import { openWebSocket, getResponseData, handleError } from './handlers'
+import { getResponseData, handleError } from './handlers'
 
 
 /**

--- a/app/src/api/handlers.js
+++ b/app/src/api/handlers.js
@@ -25,40 +25,6 @@ export async function getResponseData (response) {
 
 
 /**
- * Opens a WebSocket connection to the server in case it sends messages.
- * Currently, the connection is closed by the server right after an API call so
- * we have to open it for every calls.
- * Messages are dispatch to the store so it can handle them.
- *
- * @param {Object} request - Request info data.
- * @return {Promise<Event>} Promise that resolve on websocket 'open' or 'error' event.
- */
-export function openWebSocket (request) {
-  return new Promise(resolve => {
-    const ws = new WebSocket(`wss://${store.getters.host}/yunohost/api/messages`)
-    ws.onmessage = ({ data }) => {
-      store.dispatch('DISPATCH_MESSAGE', { request, messages: JSON.parse(data) })
-    }
-    // ws.onclose = (e) => {}
-    ws.onopen = resolve
-    // Resolve also on error so the actual fetch may be called.
-    ws.onerror = resolve
-  })
-}
-
-export function connectSSE () {
-  const host = store.getters.host.split(':')[0]
-  const evtSource = new EventSource(`https://${host}/yunohost/api/sse`)
-
-  evtSource.onmessage = (event) => {
-    store.dispatch('ON_SSE_MESSAGE', JSON.parse(atob(event.data)))
-  }
-
-  // FIXME handle 'onerror' hook
-}
-
-
-/**
  * Handler for API errors.
  *
  * @param {Object} request - Request info data.

--- a/app/src/api/handlers.js
+++ b/app/src/api/handlers.js
@@ -46,6 +46,17 @@ export function openWebSocket (request) {
   })
 }
 
+export function connectSSE () {
+  const host = store.getters.host.split(':')[0]
+  const evtSource = new EventSource(`https://${host}/yunohost/api/sse`)
+
+  evtSource.onmessage = (event) => {
+    store.dispatch('ON_SSE_MESSAGE', JSON.parse(atob(event.data)))
+  }
+
+  // FIXME handle 'onerror' hook
+}
+
 
 /**
  * Handler for API errors.

--- a/app/src/components/QueryHeader.vue
+++ b/app/src/components/QueryHeader.vue
@@ -5,7 +5,7 @@
 
     <!-- REQUEST DESCRIPTION -->
     <strong class="request-desc">
-      {{ request.humanRoute }}
+      {{ request.humanRoute || request.operationId }}
     </strong>
 
     <div v-if="request.errors || request.warnings">

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "api": {
         "partial_logs": "[...] (check in history for full logs)",
         "processing": "The server is processing the action...",
+        "external_action": "This action has been ran from another tab or from the cli",
         "query_status": {
             "error": "Unsuccessful",
             "pending": "In progress",

--- a/app/src/views/_partials/ViewLockOverlay.vue
+++ b/app/src/views/_partials/ViewLockOverlay.vue
@@ -2,7 +2,7 @@
   <b-overlay
     variant="white" opacity="0.75"
     no-center
-    :show="waiting || reconnecting || error !== null"
+    :show="(currentRequest && waiting) || reconnecting || error !== null"
   >
     <slot name="default" />
 
@@ -42,11 +42,12 @@ export default {
 
       if (error) {
         return { name: 'ErrorDisplay', request: error }
-      } else if (request.showWarningMessage) {
-        return { name: 'WarningDisplay', request }
       } else if (reconnecting) {
         return { name: 'ReconnectingDisplay' }
-      } else {
+      } else if (request) {
+        if (request.showWarningMessage) {
+          return { name: 'WarningDisplay', request }
+        }
         return { name: 'WaitingDisplay', request }
       }
     }

--- a/app/src/views/_partials/WaitingDisplay.vue
+++ b/app/src/views/_partials/WaitingDisplay.vue
@@ -3,6 +3,8 @@
   <b-card-body>
     <b-card-title class="text-center mt-4" v-t="hasMessages ? 'api.processing' : 'api_waiting'" />
 
+    <p v-if="request.external" v-t="'api.external_action'" />
+
     <!-- PROGRESS BAR -->
     <b-progress
       v-if="progress" class="my-4"


### PR DESCRIPTION
Add sse messages handling.

If a unit operation is ran from another tab or from the cli, other clients should lock themselves and display the actions logs.

TODO:
- auth ([disabled the auth part](https://github.com/YunoHost/moulinette/pull/333/files#diff-c365c99c51f165abbf9530434f7abfc4d8c3156e213b96393e1ba5916b259913R356-R362)  for now to make it work)
- close sse on logout

## PS Status
WIP

## How to test

requires:
https://github.com/YunoHost/moulinette/pull/333
https://github.com/YunoHost/yunohost/pull/1663

run commands from the cli like `user create` or `app install` and check if the web client shows the messages