### PR TITLE
Add link to the package repo

### DIFF
--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -408,6 +408,7 @@ export default {
         links: [
           ['license', `https://spdx.org/licenses/${app.manifest.upstream.license}`],
           ...['website', 'admindoc', 'userdoc', 'code'].map((key) => ([key, app.manifest.upstream[key]])),
+          ['package', app.from_catalog.git.url ],
           ['forum', `https://forum.yunohost.org/tag/${this.id}`]
         ].filter(([key, val]) => !!val),
         doc: {

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -408,8 +408,8 @@ export default {
         links: [
           ['license', `https://spdx.org/licenses/${app.manifest.upstream.license}`],
           ...['website', 'admindoc', 'userdoc', 'code'].map((key) => ([key, app.manifest.upstream[key]])),
-          ['package', app.from_catalog.git.url ],
-          ['forum', `https://forum.yunohost.org/tag/${this.id}`]
+          ['package', app.from_catalog.git.url],
+          ['forum', `https://forum.yunohost.org/tag/${app.manifest.id}`]
         ].filter(([key, val]) => !!val),
         doc: {
           notifications: {


### PR DESCRIPTION
This add a link to the package repo on the app page.
The icon was already there https://github.com/YunoHost/yunohost-admin/blob/86002daa29e88f707865d85243796e84811b131f/app/src/views/app/AppInfo.vue#L357

Yolocommit (I don't have a dev env right now)