### PR TITLE
chore: update actions version to use node 16 version

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,7 +10,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install npm dependencies
       run: cd app && npm ci
     - name: Run linter


### PR DESCRIPTION
Node 12 version is deprecated since April 2022.

> Node.js 12 actions are deprecated. For more information see: [github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2