### PR TITLE
Disable safari automatic zoom on input field

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta name="format-detection" content="telephone=no" />
-    <meta name="robots" content="noindex, nofollow">
-    <link rel="icon" href="/favicon.png">
-    <title>YunoHost Admin</title>
-  </head>
-  <body>
-    <noscript>
-      <strong>We're sorry but YunoHost Admin doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-    </noscript>
-    <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=yes">
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="/favicon.png">
+  <title>YunoHost Admin</title>
+</head>
+
+<body>
+  <noscript>
+    <strong>We're sorry but YunoHost Admin doesn't work properly without JavaScript enabled. Please enable it to
+      continue.</strong>
+  </noscript>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
on iPhone and iPad, Safari zooms automatically when the user clicks on an input field

but Safari does not automatically zoom out once the field has been filled in, so the user must do it themselves afterwards 

however, this feature makes no sense with interfaces adapted to mobile screens, so it's just annoying for nothing

so I made this PR to disable this feature 😞

the relevant code:
`maximum-scale=1, user-scalable=yes`