### PR TITLE
rename 'License' to 'App license"

### DIFF
--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -128,7 +128,7 @@
             "admindoc": "Official Admin documentation",
             "code": "Official code repository",
             "forum": "Topics about this app on YunoHost's forum",
-            "license": "License",
+            "license": "App license",
             "package": "YunoHost package repository",
             "title": "Links",
             "userdoc": "Official User documentation",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -596,7 +596,7 @@
             "title": "Liens",
             "userdoc": "Documentation officielle de l'utilisateur",
             "website": "Site officiel",
-            "license": "Licence"
+            "license": "Licence de l'app"
         },
         "potential_alternative_to": "Alternative potentielle à :",
         "upgrade": {


### PR DESCRIPTION
linked to https://github.com/YunoHost/apps/pull/2055

as i don't know how to add the "Package license" and it's link, i juste edited the "App license" text

TODO:

- [ ] show "Package license" and it's link (`<PACKAGE_REPO>/blob/master/LICENSE`) in the catalog and app install