### PR TITLE
Migration Vue3: step 1 compat mode

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -5,14 +5,23 @@ module.exports = {
     node: true,
   },
   extends: [
-    'plugin:vue/strongly-recommended',
+    'plugin:vue/vue3-strongly-recommended',
     'eslint:recommended',
     'plugin:prettier/recommended',
   ],
   rules: {
-    'no-unused-vars': [
-      'warn',
-      { varsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
-    ],
+    // 'no-unused-vars': [
+    //   'warn',
+    //   { varsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
+    // ],
+    // temp vue3 compat3
+    'vue/no-v-for-template-key-on-child': 'error',
+    'vue/no-v-for-template-key': 'off',
+    'vue/attribute-hyphenation': 'off',
+    'vue/v-on-event-hyphenation': 'off',
+    // temp flemme
+    'vue/require-explicit-emits': 'off',
+    'vue/require-default-prop': 'off',
+    'no-unused-vars': 'off',
   },
 }

--- a/app/package.json
+++ b/app/package.json
@@ -15,11 +15,12 @@
   "dependencies": {
     "@fontsource/fira-code": "^4.5.13",
     "@fontsource/firago": "^4.5.3",
+    "@vue/compat": "3.3.4",
     "bootstrap-vue": "^2.22.0",
     "date-fns": "^2.29.3",
     "fork-awesome": "^1.2.0",
     "simple-evaluate": "^1.4.6",
-    "vue": "^2.7.14",
+    "vue": "3.3.4",
     "vue-i18n": "^8.28.2",
     "vue-router": "^3.6.5",
     "vue-showdown": "^2.4.1",
@@ -27,12 +28,12 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue2": "^2.2.0",
+    "@vitejs/plugin-vue": "^5.0.4",
     "bootstrap": "^4.6.0",
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "eslint-plugin-vue": "^9.10.0",
+    "eslint-plugin-vue": "^9.22.0",
     "popper.js": "^1.16.0",
     "portal-vue": "^2.1.7",
     "prettier": "^3.2.5",

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
     "@vue/compat": "3.3.4",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
-    "bootstrap-vue": "^2.22.0",
+    "bootstrap-vue": "^2.23.1",
     "date-fns": "^2.29.3",
     "fork-awesome": "^1.2.0",
     "simple-evaluate": "^1.4.6",

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,8 @@
     "@fontsource/fira-code": "^4.5.13",
     "@fontsource/firago": "^4.5.3",
     "@vue/compat": "3.3.4",
+    "@vuelidate/core": "^2.0.3",
+    "@vuelidate/validators": "^2.0.4",
     "bootstrap-vue": "^2.22.0",
     "date-fns": "^2.29.3",
     "fork-awesome": "^1.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -24,8 +24,7 @@
     "vue-i18n": "^8.28.2",
     "vue-router": "^4.3.0",
     "vue-showdown": "^2.4.1",
-    "vuelidate": "^0.7.7",
-    "vuex": "^3.6.2"
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -13,8 +13,8 @@
     "lintfix": "prettier --write --list-different . && yarn lint:js --fix"
   },
   "dependencies": {
-    "@fontsource/fira-code": "^4.5.13",
-    "@fontsource/firago": "^4.5.3",
+    "@fontsource/fira-code": "^5.0.17",
+    "@fontsource/firago": "^5.0.7",
     "@vue/compat": "3.3.4",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
     "bootstrap-vue": "^2.23.1",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "fork-awesome": "^1.2.0",
     "simple-evaluate": "^1.4.6",
     "vue": "3.3.4",

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "fork-awesome": "^1.2.0",
     "simple-evaluate": "^1.4.6",
     "vue": "3.3.4",
-    "vue-i18n": "^8.28.2",
+    "vue-i18n": "^9.10.1",
     "vue-router": "^4.3.0",
     "vue-showdown": "^2.4.1",
     "vuex": "^4.1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "simple-evaluate": "^1.4.6",
     "vue": "3.3.4",
     "vue-i18n": "^8.28.2",
-    "vue-router": "^3.6.5",
+    "vue-router": "^4.3.0",
     "vue-showdown": "^2.4.1",
     "vuelidate": "^0.7.7",
     "vuex": "^3.6.2"

--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "vue": "3.3.4",
     "vue-i18n": "^9.10.1",
     "vue-router": "^4.3.0",
-    "vue-showdown": "^2.4.1",
+    "vue-showdown": "^4.2.0",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "portal-vue": "^2.1.7",
     "prettier": "^3.2.5",
     "sass": "^1.60.0",
-    "vite": "^4.2.1"
+    "vite": "^5.1.4"
   },
   "browserslist": [
     "> 1%",

--- a/app/package.json
+++ b/app/package.json
@@ -31,14 +31,14 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "bootstrap": "^4.6.0",
-    "eslint": "^8.36.0",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.22.0",
     "popper.js": "^1.16.0",
     "portal-vue": "^2.1.7",
     "prettier": "^3.2.5",
-    "sass": "^1.60.0",
+    "sass": "^1.71.1",
     "vite": "^5.1.4"
   },
   "browserslist": [

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -6,7 +6,6 @@
         <BNavbarBrand
           :to="{ name: 'home' }"
           :disabled="waiting"
-          exact
           exact-active-class="active"
         >
           <span v-if="theme">
@@ -45,10 +44,12 @@
       <main id="main">
         <!-- The `key` on RouterView make sure that if a link points to a page that
         use the same component as the previous one, it will be refreshed -->
-        <Transition v-if="transitions" :name="transitionName">
-          <RouterView class="animated" :key="routerKey" />
-        </Transition>
-        <RouterView v-else class="static" :key="routerKey" />
+        <RouterView v-slot="{ Component }" :key="routerKey">
+          <Transition v-if="transitions" :name="transitionName">
+            <Component :is="Component" class="animated" />
+          </Transition>
+          <Component v-else :is="Component" class="static" />
+        </RouterView>
       </main>
     </ViewLockOverlay>
 

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -101,6 +101,7 @@ import { mapGetters } from 'vuex'
 import { HistoryConsole, ViewLockOverlay } from '@/views/_partials'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'App',
 
   components: {

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -227,7 +227,7 @@ main {
   .animated {
     transition: all 0.15s ease-in-out;
   }
-  .slide-left-enter,
+  .slide-left-enter-from,
   .slide-right-leave-active {
     position: absolute;
     width: 100%;
@@ -235,7 +235,7 @@ main {
     transform: translate(100vw, 0);
   }
   .slide-left-leave-active,
-  .slide-right-enter {
+  .slide-right-enter-from {
     position: absolute;
     width: 100%;
     top: 0;

--- a/app/src/api/errors.js
+++ b/app/src/api/errors.js
@@ -10,7 +10,7 @@ class APIError extends Error {
     super(
       error
         ? error.replaceAll('\n', '<br>')
-        : i18n.t('error_server_unexpected'),
+        : i18n.global.t('error_server_unexpected'),
     )
     const urlObj = new URL(url)
     this.name = 'APIError'
@@ -39,7 +39,9 @@ class APIErrorLog extends APIError {
 // 0 — (means "the connexion has been closed" apparently)
 class APIConnexionError extends APIError {
   constructor(method, response) {
-    super(method, response, { error: i18n.t('error_connection_interrupted') })
+    super(method, response, {
+      error: i18n.global.t('error_connection_interrupted'),
+    })
     this.name = 'APIConnexionError'
   }
 }
@@ -57,7 +59,7 @@ class APIBadRequestError extends APIError {
 // 401 — Unauthorized
 class APIUnauthorizedError extends APIError {
   constructor(method, response, errorData) {
-    super(method, response, { error: i18n.t('unauthorized') })
+    super(method, response, { error: i18n.global.t('unauthorized') })
     this.name = 'APIUnauthorizedError'
   }
 }
@@ -65,7 +67,7 @@ class APIUnauthorizedError extends APIError {
 // 404 — Not Found
 class APINotFoundError extends APIError {
   constructor(method, response, errorData) {
-    errorData.error = i18n.t('api_not_found')
+    errorData.error = i18n.global.t('api_not_found')
     super(method, response, errorData)
     this.name = 'APINotFoundError'
   }
@@ -83,7 +85,7 @@ class APIInternalError extends APIError {
 // 502 — Bad gateway (means API is down)
 class APINotRespondingError extends APIError {
   constructor(method, response) {
-    super(method, response, { error: i18n.t('api_not_responding') })
+    super(method, response, { error: i18n.global.t('api_not_responding') })
     this.name = 'APINotRespondingError'
   }
 }

--- a/app/src/components/AdressInputSelect.vue
+++ b/app/src/components/AdressInputSelect.vue
@@ -39,6 +39,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AdressInputSelect',
 
   inheritAttrs: false,

--- a/app/src/components/AdressInputSelect.vue
+++ b/app/src/components/AdressInputSelect.vue
@@ -2,24 +2,24 @@
   <BInputGroup v-bind="$attrs">
     <InputItem
       :id="id"
-      :value="value.localPart"
+      :modelValue="modelValue.localPart"
       :placeholder="placeholder"
       :state="state"
       :aria-describedby="id + 'local-part-desc'"
-      @input="onInput('localPart', $event)"
+      @update:modelValue="onInput('localPart', $event)"
       @blur="$parent.$emit('touch')"
     />
 
     <BInputGroupAppend>
-      <BInputGroupText>{{ value.separator }}</BInputGroupText>
+      <BInputGroupText>{{ modelValue.separator }}</BInputGroupText>
     </BInputGroupAppend>
 
     <BInputGroupAppend>
       <SelectItem
-        :value="value.domain"
+        :modelValue="modelValue.domain"
         :choices="choices"
         :aria-describedby="id + 'domain-desc'"
-        @input="onInput('domain', $event)"
+        @update:modelValue="onInput('domain', $event)"
         @blur="$parent.$emit('touch')"
       />
     </BInputGroupAppend>
@@ -45,8 +45,7 @@ export default {
   inheritAttrs: false,
 
   props: {
-    // `value` is actually passed thru the `v-model` directive
-    value: { type: Object, required: true },
+    modelValue: { type: Object, required: true },
     choices: { type: Array, required: true },
     placeholder: { type: String, default: null },
     id: { type: String, default: null },
@@ -55,10 +54,10 @@ export default {
   },
 
   methods: {
-    onInput(key, value) {
-      this.$emit('input', {
-        ...this.value,
-        [key]: value,
+    onInput(key, modelValue) {
+      this.$emit('update:modelValue', {
+        ...this.modelValue,
+        [key]: modelValue,
       })
     },
   },

--- a/app/src/components/CardCollapse.vue
+++ b/app/src/components/CardCollapse.vue
@@ -23,6 +23,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardCollapse',
 
   props: {

--- a/app/src/components/CardDeckFeed.vue
+++ b/app/src/components/CardDeckFeed.vue
@@ -1,6 +1,8 @@
 <script>
 // Implementation of the feed pattern
 // https://www.w3.org/WAI/ARIA/apg/patterns/feed/
+import { h } from 'vue'
+import { BCardGroup } from 'bootstrap-vue'
 
 export default {
   compatConfig: { MODE: 3 },
@@ -67,12 +69,13 @@ export default {
     }
   },
 
-  render(h) {
+  render() {
     return h(
-      'BCardGroup',
+      BCardGroup,
       {
-        attrs: { role: 'feed', 'aria-busy': this.busy.toString() },
-        props: { deck: true },
+        deck: true,
+        role: 'feed',
+        'aria-busy': this.busy.toString(),
         ref: 'feed',
       },
       this.$slots.default().slice(0, this.range),

--- a/app/src/components/CardDeckFeed.vue
+++ b/app/src/components/CardDeckFeed.vue
@@ -14,7 +14,7 @@ export default {
     return {
       busy: false,
       range: this.stacks,
-      childrenCount: this.$slots.default.length,
+      childrenCount: this.$slots.default().length,
     }
   },
 
@@ -60,7 +60,7 @@ export default {
   },
 
   beforeUpdate() {
-    const slots = this.$slots.default
+    const slots = this.$slots.default()
     if (this.childrenCount !== slots.length) {
       this.range = this.stacks
       this.childrenCount = slots.length
@@ -75,7 +75,7 @@ export default {
         props: { deck: true },
         ref: 'feed',
       },
-      this.$slots.default.slice(0, this.range),
+      this.$slots.default().slice(0, this.range),
     )
   },
 

--- a/app/src/components/CardDeckFeed.vue
+++ b/app/src/components/CardDeckFeed.vue
@@ -3,6 +3,7 @@
 // https://www.w3.org/WAI/ARIA/apg/patterns/feed/
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardDeckFeed',
 
   props: {

--- a/app/src/components/CardDeckFeed.vue
+++ b/app/src/components/CardDeckFeed.vue
@@ -79,7 +79,7 @@ export default {
     )
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener('scroll', this.onScroll)
     this.$refs.feed.removeEventListener('keydown', this.onKeydown)
   },

--- a/app/src/components/ConfigPanel.vue
+++ b/app/src/components/ConfigPanel.vue
@@ -54,6 +54,7 @@
 import { filterObject } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ConfigPanel',
 
   props: {

--- a/app/src/components/ConfigPanel.vue
+++ b/app/src/components/ConfigPanel.vue
@@ -6,7 +6,7 @@
       validation,
       serverError: panel.serverError,
     }"
-    @submit.prevent.stop="onApply"
+    @apply="onApply"
     :no-footer="!panel.hasApplyButton"
   >
     <slot name="tab-top" />
@@ -78,7 +78,7 @@ export default {
     onApply() {
       const panelId = this.panel.id
 
-      this.$emit('submit', {
+      this.$emit('apply', {
         id: panelId,
         form: this.forms[panelId],
       })
@@ -88,7 +88,7 @@ export default {
       const panelId = this.panel.id
       const actionFieldsKeys = Object.keys(actionFields)
 
-      this.$emit('submit', {
+      this.$emit('apply', {
         id: panelId,
         form: filterObject(this.forms[panelId], ([key]) =>
           actionFieldsKeys.includes(key),

--- a/app/src/components/ConfigPanel.vue
+++ b/app/src/components/ConfigPanel.vue
@@ -105,7 +105,7 @@ export default {
   margin-bottom: 1em;
   border-bottom: solid $border-width $gray-500;
 }
-::v-deep .panel-section:not(:last-child) {
+:deep(.panel-section:not(:last-child)) {
   margin-bottom: 3rem;
 }
 </style>

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -3,7 +3,7 @@
     <RoutableTabs
       v-if="routes_.length > 1"
       :routes="routes_"
-      v-bind="{ panels, forms, v: $v, ...$attrs }"
+      v-bind="{ panels, forms, v: v$, ...$attrs }"
       v-on="$listeners"
     >
       <template #tab-top>
@@ -26,7 +26,8 @@
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { toRef } from 'vue'
+import { useVuelidate } from '@vuelidate/core'
 
 export default {
   name: 'ConfigPanels',
@@ -37,8 +38,6 @@ export default {
     RoutableTabs: () => import('@/components/RoutableTabs.vue'),
   },
 
-  mixins: [validationMixin],
-
   props: {
     panels: { type: Array, default: undefined },
     forms: { type: Object, default: undefined },
@@ -46,6 +45,14 @@ export default {
     errors: { type: Object, default: undefined }, // never used
     routes: { type: Array, default: null },
     noRedirect: { type: Boolean, default: false },
+    externalResults: { type: Object, required: true },
+  },
+
+  setup(props) {
+    const externalResults = toRef(props, 'externalResults')
+    return {
+      v$: useVuelidate({ $externalResults: externalResults, $autoDirty: true }),
+    }
   },
 
   computed: {

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -28,6 +28,7 @@
 
 <script>
 import { toRef } from 'vue'
+import { defineAsyncComponent } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 
 export default {
@@ -37,7 +38,9 @@ export default {
   inheritAttrs: false,
 
   components: {
-    RoutableTabs: () => import('@/components/RoutableTabs.vue'),
+    RoutableTabs: defineAsyncComponent(
+      () => import('@/components/RoutableTabs.vue'),
+    ),
   },
 
   props: {

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -2,8 +2,8 @@
   <div class="config-panel">
     <RoutableTabs
       v-if="routes_.length > 1"
-      :routes="routes_"
       v-bind="{ panels, forms, v: v$, ...$attrs }"
+      :routes="routes_"
       v-on="$listeners"
     >
       <template #tab-top>

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="config-panel">
+    <!-- FIXME vue3 - weird stuff with event binding, need to propagate by hand for now -->
     <RoutableTabs
       v-if="routes_.length > 1"
       v-bind="{ panels, forms, v: v$, ...$attrs }"
       :routes="routes_"
-      v-on="$listeners"
+      @apply="$emit('apply', $event)"
     >
       <template #tab-top>
         <slot name="tab-top" />

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -30,6 +30,7 @@ import { toRef } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ConfigPanels',
 
   inheritAttrs: false,

--- a/app/src/components/LazyRenderer.vue
+++ b/app/src/components/LazyRenderer.vue
@@ -70,7 +70,7 @@ export default {
     this.observer.observe(this.$el)
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     this.observer.disconnect()
   },
 }

--- a/app/src/components/LazyRenderer.vue
+++ b/app/src/components/LazyRenderer.vue
@@ -6,6 +6,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'LazyRenderer',
 
   props: {

--- a/app/src/components/MessageListGroup.vue
+++ b/app/src/components/MessageListGroup.vue
@@ -66,7 +66,7 @@ export default {
 
   created() {
     if (this.autoScroll) {
-      this.$watch('messages', this.scrollToEnd)
+      this.$watch('messages', this.scrollToEnd, { deep: true })
     }
   },
 }

--- a/app/src/components/MessageListGroup.vue
+++ b/app/src/components/MessageListGroup.vue
@@ -24,6 +24,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'MessageListGroup',
 
   props: {

--- a/app/src/components/QueryHeader.vue
+++ b/app/src/components/QueryHeader.vue
@@ -49,6 +49,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'QueryHeader',
 
   props: {

--- a/app/src/components/QueryHeader.vue
+++ b/app/src/components/QueryHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-bind="$attrs" class="query-header w-100" v-on="$listeners">
+  <div v-bind="$attrs" class="query-header w-100">
     <!-- STATUS -->
     <span
       class="status"

--- a/app/src/components/QueryHeader.vue
+++ b/app/src/components/QueryHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="query-header w-100" v-on="$listeners" v-bind="$attrs">
+  <div v-bind="$attrs" class="query-header w-100" v-on="$listeners">
     <!-- STATUS -->
     <span
       class="status"

--- a/app/src/components/RecursiveListGroup.vue
+++ b/app/src/components/RecursiveListGroup.vue
@@ -45,6 +45,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'RecursiveListGroup',
 
   props: {

--- a/app/src/components/RecursiveListGroup.vue
+++ b/app/src/components/RecursiveListGroup.vue
@@ -1,8 +1,7 @@
 <template>
   <BListGroup :flush="flush" :style="{ '--depth': tree.depth }">
-    <template v-for="(node, i) in tree.children">
+    <template v-for="(node, i) in tree.children" :key="node.id">
       <BListGroupItem
-        :key="node.id"
         class="list-group-item-action"
         :class="getClasses(node, i)"
         @click="$router.push(node.data.to)"
@@ -26,7 +25,6 @@
 
       <BCollapse
         v-if="node.children"
-        :key="'collapse-' + node.id"
         v-model="node.data.opened"
         :id="'collapse-' + node.id"
       >

--- a/app/src/components/RecursiveListGroup.vue
+++ b/app/src/components/RecursiveListGroup.vue
@@ -34,7 +34,7 @@
           flush
         >
           <!-- PASS THE DEFAULT SLOT WITH SCOPE TO NEXT NESTED COMPONENT -->
-          <template slot="default" slot-scope="scope">
+          <template #default="scope">
             <slot name="default" v-bind="scope" />
           </template>
         </RecursiveListGroup>

--- a/app/src/components/RoutableTabs.vue
+++ b/app/src/components/RoutableTabs.vue
@@ -16,7 +16,12 @@
 
     <!-- Bind extra props to the child view and forward child events to parent -->
     <RouterView v-slot="{ Component }">
-      <Component v-bind="$attrs" v-on="$listeners" :is="Component">
+      <Component
+        v-bind="$attrs"
+        :is="Component"
+        v-on="$listeners"
+        @apply="$emit('apply', $event)"
+      >
         <template #tab-top>
           <slot name="tab-top" />
         </template>

--- a/app/src/components/RoutableTabs.vue
+++ b/app/src/components/RoutableTabs.vue
@@ -6,7 +6,6 @@
           v-for="route in routes"
           :key="route.text"
           :to="route.to"
-          exact
           exact-active-class="active"
         >
           <YIcon v-if="route.icon" :iname="route.icon" />
@@ -16,16 +15,18 @@
     </BCardHeader>
 
     <!-- Bind extra props to the child view and forward child events to parent -->
-    <RouterView v-bind="$attrs" v-on="$listeners">
-      <template #tab-top>
-        <slot name="tab-top" />
-      </template>
-      <template #tab-before>
-        <slot name="tab-before" />
-      </template>
-      <template #tab-after>
-        <slot name="tab-after" />
-      </template>
+    <RouterView v-slot="{ Component }">
+      <Component v-bind="$attrs" v-on="$listeners" :is="Component">
+        <template #tab-top>
+          <slot name="tab-top" />
+        </template>
+        <template #tab-before>
+          <slot name="tab-before" />
+        </template>
+        <template #tab-after>
+          <slot name="tab-after" />
+        </template>
+      </Component>
     </RouterView>
   </BCard>
 </template>

--- a/app/src/components/RoutableTabs.vue
+++ b/app/src/components/RoutableTabs.vue
@@ -33,6 +33,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'RoutableTabs',
 
   // Thanks to `v-bind="$attrs"` and `inheritAttrs: false`, this component can forward

--- a/app/src/components/RoutableTabs.vue
+++ b/app/src/components/RoutableTabs.vue
@@ -19,7 +19,6 @@
       <Component
         v-bind="$attrs"
         :is="Component"
-        v-on="$listeners"
         @apply="$emit('apply', $event)"
       >
         <template #tab-top>

--- a/app/src/components/globals/AbstractForm.vue
+++ b/app/src/components/globals/AbstractForm.vue
@@ -7,8 +7,8 @@
         :id="id"
         :inline="inline"
         :class="formClasses"
-        @submit.prevent="onSubmit"
         novalidate
+        @submit.prevent.stop="onSubmit"
       >
         <slot name="default" />
 
@@ -61,7 +61,8 @@ export default {
         v.$touch()
         if (v.$pending || v.$errors.length) return
       }
-      this.$emit('submit', e)
+      // Weird bug with `INSTANCE_LISTENERS: true` with 'submit' event (double exec before of conflict with native submit event?)
+      this.$emit('apply')
     },
   },
 }

--- a/app/src/components/globals/AbstractForm.vue
+++ b/app/src/components/globals/AbstractForm.vue
@@ -47,7 +47,7 @@ export default {
   computed: {
     errorFeedback() {
       if (this.serverError) return this.serverError
-      else if (this.validation && this.validation.$anyError) {
+      else if (this.validation && this.validation.$errors.length) {
         return this.$i18n.t('form_errors.invalid_form')
       } else return ''
     },
@@ -58,7 +58,7 @@ export default {
       const v = this.validation
       if (v) {
         v.$touch()
-        if (v.$pending || v.$invalid) return
+        if (v.$pending || v.$errors.length) return
       }
       this.$emit('submit', e)
     },

--- a/app/src/components/globals/AbstractForm.vue
+++ b/app/src/components/globals/AbstractForm.vue
@@ -32,6 +32,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AbstractForm',
 
   props: {

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -52,7 +52,7 @@ export default {
   computed: {
     errorFeedback() {
       if (this.serverError) return this.serverError
-      else if (this.validation && this.validation.$anyError) {
+      else if (this.validation && this.validation.$errors.length) {
         return this.$i18n.t('form_errors.invalid_form')
       } else return ''
     },

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -37,6 +37,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardForm',
 
   props: {

--- a/app/src/components/globals/DescriptionRow.vue
+++ b/app/src/components/globals/DescriptionRow.vue
@@ -16,6 +16,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DescriptionRow',
 
   props: {

--- a/app/src/components/globals/ExplainWhat.vue
+++ b/app/src/components/globals/ExplainWhat.vue
@@ -24,6 +24,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ExplainWhat',
 
   props: {

--- a/app/src/components/globals/ExplainWhat.vue
+++ b/app/src/components/globals/ExplainWhat.vue
@@ -57,7 +57,7 @@ export default {
     background-color: $white;
     border-width: 2px;
 
-    ::v-deep .popover-body {
+    :deep(.popover-body) {
       color: $dark;
     }
   }

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -145,7 +145,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .invalid-feedback code {
+:deep(.invalid-feedback code) {
   background-color: $gray-200;
 }
 </style>

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -14,7 +14,8 @@
         v-bind="props"
         :is="component"
         v-on="$listeners"
-        :value="value"
+        :modelValue="modelValue"
+        @update:modelValue="$emit('update:modelValue', $event)"
         :state="state"
         :required="validation ? 'required' in validation : false"
       />
@@ -62,7 +63,7 @@ export default {
     link: { type: Object, default: null },
     // Rendered field component props
     component: { type: String, default: 'InputItem' },
-    value: { type: null, default: null },
+    modelValue: { type: null, default: null },
     props: { type: Object, default: () => ({}) },
     validation: { type: Object, default: null },
     validationIndex: { type: Number, default: null },

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -49,6 +49,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'FormField',
 
   inheritAttrs: false,

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -11,8 +11,8 @@
     <slot v-bind="{ self: { ...props, state }, touch }">
       <!-- if no component was passed as slot, render a component from the props -->
       <Component
-        :is="component"
         v-bind="props"
+        :is="component"
         v-on="$listeners"
         :value="value"
         :state="state"

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -36,7 +36,6 @@
         <VueShowdown
           v-if="description"
           :markdown="description"
-          flavor="github"
           :class="{
             ['alert p-1 px-2 alert-' + descriptionVariant]: descriptionVariant,
           }"

--- a/app/src/components/globals/FormField.vue
+++ b/app/src/components/globals/FormField.vue
@@ -13,7 +13,6 @@
       <Component
         v-bind="props"
         :is="component"
-        v-on="$listeners"
         :modelValue="modelValue"
         @update:modelValue="$emit('update:modelValue', $event)"
         :state="state"

--- a/app/src/components/globals/ReadOnlyField.vue
+++ b/app/src/components/globals/ReadOnlyField.vue
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ReadOnlyField',
 
   inheritAttrs: false,

--- a/app/src/components/globals/TopBar.vue
+++ b/app/src/components/globals/TopBar.vue
@@ -16,6 +16,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'TopBar',
 
   props: {

--- a/app/src/components/globals/TopBar.vue
+++ b/app/src/components/globals/TopBar.vue
@@ -67,7 +67,7 @@ export default {
     #top-bar-right {
       margin-bottom: 0.75rem;
 
-      ::v-deep > * {
+      :deep(> *) {
         margin-bottom: 0.25rem;
       }
     }
@@ -88,7 +88,7 @@ export default {
       margin-left: auto;
     }
 
-    ::v-deep .btn {
+    :deep(.btn) {
       margin-left: 0.5rem;
       &.dropdown-toggle-split {
         margin-left: 0;

--- a/app/src/components/globals/ViewBase.vue
+++ b/app/src/components/globals/ViewBase.vue
@@ -33,6 +33,7 @@
 import api from '@/api'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ViewBase',
 
   props: {

--- a/app/src/components/globals/ViewSearch.vue
+++ b/app/src/components/globals/ViewSearch.vue
@@ -57,6 +57,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ViewSearch',
 
   props: {

--- a/app/src/components/globals/ViewSearch.vue
+++ b/app/src/components/globals/ViewSearch.vue
@@ -57,7 +57,7 @@
 
 <script>
 export default {
-  compatConfig: { MODE: 3 },
+  compatConfig: { MODE: 3, INSTANCE_LISTENERS: false },
   name: 'ViewSearch',
 
   props: {

--- a/app/src/components/globals/ViewSearch.vue
+++ b/app/src/components/globals/ViewSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <ViewBase v-bind="$attrs" v-on="$listeners" :skeleton="skeleton">
+  <ViewBase v-bind="$attrs" :skeleton="skeleton">
     <template v-if="hasCustomTopBar" #top-bar>
       <slot name="top-bar" />
     </template>

--- a/app/src/components/globals/YAlert.vue
+++ b/app/src/components/globals/YAlert.vue
@@ -18,6 +18,7 @@
 import { DEFAULT_STATUS_ICON } from '@/helpers/yunohostArguments'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YAlert',
 
   props: {

--- a/app/src/components/globals/YBreadcrumb.vue
+++ b/app/src/components/globals/YBreadcrumb.vue
@@ -20,6 +20,7 @@
 import { mapGetters } from 'vuex'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YBreadcrumb',
 
   computed: {

--- a/app/src/components/globals/YCard.vue
+++ b/app/src/components/globals/YCard.vue
@@ -83,7 +83,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.card-header {
+:deep(.card-header) {
   display: flex;
 
   .custom-header {
@@ -97,7 +97,7 @@ export default {
   }
 }
 
-.card-footer {
+:deep(.card-footer) {
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -106,7 +106,7 @@ export default {
     margin-left: 0.5rem;
   }
 }
-.collapse:not(.show) + .card-footer {
+:deep(.collapse:not(.show) + .card-footer) {
   display: none;
 }
 </style>

--- a/app/src/components/globals/YCard.vue
+++ b/app/src/components/globals/YCard.vue
@@ -56,6 +56,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YCard',
 
   props: {

--- a/app/src/components/globals/YIcon.vue
+++ b/app/src/components/globals/YIcon.vue
@@ -7,6 +7,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YIcon',
   props: {
     iname: { type: String, required: true },

--- a/app/src/components/globals/YListGroupItem.vue
+++ b/app/src/components/globals/YListGroupItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <BListGroupItem class="yuno-list-group-item" :class="_class" v-bind="$attrs">
+  <BListGroupItem v-bind="$attrs" class="yuno-list-group-item" :class="_class">
     <div v-if="!noStatus" class="yuno-list-group-item-status">
       <YIcon v-if="_icon" :iname="_icon" :class="['icon-' + variant]" />
     </div>

--- a/app/src/components/globals/YListGroupItem.vue
+++ b/app/src/components/globals/YListGroupItem.vue
@@ -14,6 +14,7 @@
 import { DEFAULT_STATUS_ICON } from '@/helpers/yunohostArguments'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YListGroupItem',
 
   props: {

--- a/app/src/components/globals/YSpinner.vue
+++ b/app/src/components/globals/YSpinner.vue
@@ -6,6 +6,7 @@
 import { mapGetters } from 'vuex'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'YSpinner',
 
   computed: {

--- a/app/src/components/globals/formItems/ButtonItem.vue
+++ b/app/src/components/globals/formItems/ButtonItem.vue
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ButtonItem',
 
   props: {

--- a/app/src/components/globals/formItems/CheckboxItem.vue
+++ b/app/src/components/globals/formItems/CheckboxItem.vue
@@ -1,12 +1,14 @@
 <template>
+  <!-- FIXME vue3 - `modelValue`+`@update:model` doesn't work here, probably to the prop's name not being `value`. Sticking for now to `checked`+`@input` -->
   <BFormCheckbox
-    v-model="checked"
+    :checked="modelValue"
+    @input="$emit('update:modelValue', $event)"
     v-on="$listeners"
     :id="id"
     :aria-describedby="$parent.id + '__BV_description_'"
     switch
   >
-    {{ label || $t(labels[checked]) }}
+    {{ label || $t(labels[modelValue]) }}
   </BFormCheckbox>
 </template>
 
@@ -16,16 +18,10 @@ export default {
   name: 'CheckboxItem',
 
   props: {
-    value: { type: Boolean, required: true },
+    modelValue: { type: Boolean, required: true },
     id: { type: String, default: null },
     label: { type: String, default: null },
     labels: { type: Object, default: () => ({ true: 'yes', false: 'no' }) },
-  },
-
-  data() {
-    return {
-      checked: this.value,
-    }
   },
 }
 </script>

--- a/app/src/components/globals/formItems/CheckboxItem.vue
+++ b/app/src/components/globals/formItems/CheckboxItem.vue
@@ -3,7 +3,6 @@
   <BFormCheckbox
     :checked="modelValue"
     @input="$emit('update:modelValue', $event)"
-    v-on="$listeners"
     :id="id"
     :aria-describedby="$parent.id + '__BV_description_'"
     switch

--- a/app/src/components/globals/formItems/CheckboxItem.vue
+++ b/app/src/components/globals/formItems/CheckboxItem.vue
@@ -12,6 +12,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CheckboxItem',
 
   props: {

--- a/app/src/components/globals/formItems/DisplayTextItem.vue
+++ b/app/src/components/globals/formItems/DisplayTextItem.vue
@@ -6,6 +6,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DisplayTextItem',
 
   props: {

--- a/app/src/components/globals/formItems/FileItem.vue
+++ b/app/src/components/globals/formItems/FileItem.vue
@@ -30,6 +30,7 @@
 import { getFileContent } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'FileItem',
 
   props: {

--- a/app/src/components/globals/formItems/FileItem.vue
+++ b/app/src/components/globals/formItems/FileItem.vue
@@ -1,7 +1,7 @@
 <template>
   <BButtonGroup class="w-100">
     <BButton
-      v-if="!this.required && this.value.file !== null"
+      v-if="!this.required && this.modelValue.file !== null"
       @click="clearFiles"
       variant="danger"
     >
@@ -10,7 +10,7 @@
     </BButton>
 
     <BFormFile
-      :value="value.file"
+      :modelValue="modelValue.file"
       ref="input-file"
       :id="id"
       :required="required"
@@ -35,7 +35,7 @@ export default {
 
   props: {
     id: { type: String, default: null },
-    value: { type: Object, default: () => ({ file: null }) },
+    modelValue: { type: Object, default: () => ({ file: null }) },
     placeholder: { type: String, default: 'Choose a file or drop it here...' },
     dropPlaceholder: { type: String, default: null },
     accept: { type: String, default: null },
@@ -46,7 +46,9 @@ export default {
 
   computed: {
     _placeholder: function () {
-      return this.value.file === null ? this.placeholder : this.value.file.name
+      return this.modelValue.file === null
+        ? this.placeholder
+        : this.modelValue.file.name
     },
   },
 
@@ -59,17 +61,17 @@ export default {
         removed: false,
       }
       // Update the value with the new File and an empty content for now
-      this.$emit('input', value)
+      this.$emit('update:modelValue', value)
 
       // Asynchronously load the File content and update the value again
       getFileContent(file).then((content) => {
-        this.$emit('input', { ...value, content })
+        this.$emit('update:modelValue', { ...value, content })
       })
     },
 
     clearFiles() {
       this.$refs['input-file'].reset()
-      this.$emit('input', {
+      this.$emit('update:modelValue', {
         file: null,
         content: '',
         current: false,

--- a/app/src/components/globals/formItems/FileItem.vue
+++ b/app/src/components/globals/formItems/FileItem.vue
@@ -80,7 +80,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .custom-file-label {
+:deep(.custom-file-label) {
   color: $input-placeholder-color;
 
   .btn-danger + .b-form-file & {

--- a/app/src/components/globals/formItems/InputItem.vue
+++ b/app/src/components/globals/formItems/InputItem.vue
@@ -18,6 +18,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'InputItem',
 
   props: {

--- a/app/src/components/globals/formItems/InputItem.vue
+++ b/app/src/components/globals/formItems/InputItem.vue
@@ -12,7 +12,6 @@
     :step="step"
     :trim="trim"
     :autocomplete="autocomplete_"
-    v-on="$listeners"
     @blur="$parent.$emit('touch', name)"
   />
 </template>

--- a/app/src/components/globals/formItems/InputItem.vue
+++ b/app/src/components/globals/formItems/InputItem.vue
@@ -1,6 +1,7 @@
 <template>
   <BFormInput
-    :value="value"
+    :modelValue="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
     :id="id"
     :placeholder="placeholder"
     :type="type"
@@ -22,7 +23,7 @@ export default {
   name: 'InputItem',
 
   props: {
-    value: { type: [String, Number], default: null },
+    modelValue: { type: [String, Number], default: null },
     id: { type: String, default: null },
     placeholder: { type: String, default: null },
     type: { type: String, default: 'text' },

--- a/app/src/components/globals/formItems/MarkdownItem.vue
+++ b/app/src/components/globals/formItems/MarkdownItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <VueShowdown :markdown="label" flavor="github" />
+  <VueShowdown :markdown="label" />
 </template>
 
 <script>

--- a/app/src/components/globals/formItems/MarkdownItem.vue
+++ b/app/src/components/globals/formItems/MarkdownItem.vue
@@ -4,6 +4,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'MarkdownItem',
 
   props: {

--- a/app/src/components/globals/formItems/ReadOnlyAlertItem.vue
+++ b/app/src/components/globals/formItems/ReadOnlyAlertItem.vue
@@ -6,12 +6,7 @@
   >
     <YIcon :iname="icon_" class="mr-md-3 mb-md-0 mb-2" :variant="type" />
 
-    <VueShowdown
-      :markdown="label"
-      flavor="github"
-      tag="span"
-      class="markdown"
-    />
+    <VueShowdown :markdown="label" tag="span" class="markdown" />
   </BAlert>
 </template>
 

--- a/app/src/components/globals/formItems/ReadOnlyAlertItem.vue
+++ b/app/src/components/globals/formItems/ReadOnlyAlertItem.vue
@@ -12,6 +12,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ReadOnlyAlertItem',
 
   props: {

--- a/app/src/components/globals/formItems/SelectItem.vue
+++ b/app/src/components/globals/formItems/SelectItem.vue
@@ -11,6 +11,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SelectItem',
 
   props: {

--- a/app/src/components/globals/formItems/SelectItem.vue
+++ b/app/src/components/globals/formItems/SelectItem.vue
@@ -5,7 +5,6 @@
     :id="id"
     :options="choices"
     :required="required"
-    v-on="$listeners"
     @blur.native="$emit('blur', modelValue)"
   />
 </template>

--- a/app/src/components/globals/formItems/SelectItem.vue
+++ b/app/src/components/globals/formItems/SelectItem.vue
@@ -1,11 +1,12 @@
 <template>
   <BFormSelect
-    :value="value"
+    :modelValue="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
     :id="id"
     :options="choices"
     :required="required"
     v-on="$listeners"
-    @blur.native="$emit('blur', value)"
+    @blur.native="$emit('blur', modelValue)"
   />
 </template>
 
@@ -15,7 +16,7 @@ export default {
   name: 'SelectItem',
 
   props: {
-    value: { type: [String, null], default: null },
+    modelValue: { type: [String, null], default: null },
     id: { type: String, default: null },
     choices: { type: [Array, Object], required: true },
     required: { type: Boolean, default: false },

--- a/app/src/components/globals/formItems/TagsItem.vue
+++ b/app/src/components/globals/formItems/TagsItem.vue
@@ -16,6 +16,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'TagsItem',
 
   data() {

--- a/app/src/components/globals/formItems/TagsItem.vue
+++ b/app/src/components/globals/formItems/TagsItem.vue
@@ -10,7 +10,6 @@
     remove-on-delete
     :state="state"
     :options="options"
-    v-on="$listeners"
     @blur="$parent.$emit('touch', name)"
   />
 </template>

--- a/app/src/components/globals/formItems/TagsItem.vue
+++ b/app/src/components/globals/formItems/TagsItem.vue
@@ -1,6 +1,7 @@
 <template>
   <BFormTags
-    v-model="tags"
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event)"
     :id="id"
     :placeholder="placeholder"
     :required="required"
@@ -19,13 +20,8 @@ export default {
   compatConfig: { MODE: 3 },
   name: 'TagsItem',
 
-  data() {
-    return {
-      tags: this.value,
-    }
-  },
   props: {
-    value: { type: Array, default: null },
+    modelValue: { type: Array, default: null },
     id: { type: String, default: null },
     placeholder: { type: String, default: null },
     limit: { type: Number, default: null },

--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -3,7 +3,8 @@
     <BFormTags
       v-bind="$attrs"
       v-on="$listeners"
-      :value="value"
+      :modelValue="modelValue"
+      @update:modelValue="$emit('update:modelValue', $event)"
       :id="id"
       size="lg"
       class="p-0 border-0"
@@ -99,7 +100,7 @@ export default {
   inheritAttrs: false,
 
   props: {
-    value: { type: Array, required: true },
+    modelValue: { type: Array, required: true },
     options: { type: Array, required: true },
     id: { type: String, required: true },
     placeholder: { type: String, default: null },
@@ -129,7 +130,8 @@ export default {
       const criteria = this.criteria
       const options = this.options.filter((opt) => {
         return (
-          this.value.indexOf(opt) === -1 && !this.disabledItems.includes(opt)
+          this.modelValue.indexOf(opt) === -1 &&
+          !this.disabledItems.includes(opt)
         )
       })
       if (criteria) {

--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -93,6 +93,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'TagsSelectizeItem',
 
   inheritAttrs: false,

--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -2,7 +2,6 @@
   <div class="tags-selectize">
     <BFormTags
       v-bind="$attrs"
-      v-on="$listeners"
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
       :id="id"

--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -176,7 +176,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .dropdown-menu {
+:deep(.dropdown-menu) {
   max-height: 300px;
   overflow-y: auto;
   padding-top: 0;

--- a/app/src/components/globals/formItems/TextAreaItem.vue
+++ b/app/src/components/globals/formItems/TextAreaItem.vue
@@ -1,6 +1,7 @@
 <template>
   <BFormTextarea
-    :value="value"
+    :modelValue="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
     :id="id"
     :placeholder="placeholder"
     :required="required"
@@ -17,7 +18,7 @@ export default {
   name: 'TextAreaItem',
 
   props: {
-    value: { type: String, default: null },
+    modelValue: { type: String, default: null },
     id: { type: String, default: null },
     placeholder: { type: String, default: null },
     type: { type: String, default: 'text' },

--- a/app/src/components/globals/formItems/TextAreaItem.vue
+++ b/app/src/components/globals/formItems/TextAreaItem.vue
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'TextAreaItem',
 
   props: {

--- a/app/src/components/globals/formItems/TextAreaItem.vue
+++ b/app/src/components/globals/formItems/TextAreaItem.vue
@@ -7,7 +7,6 @@
     :required="required"
     :state="state"
     rows="4"
-    v-on="$listeners"
     @blur="$parent.$emit('touch', name)"
   />
 </template>

--- a/app/src/components/globals/skeletons/CardButtonsSkeleton.vue
+++ b/app/src/components/globals/skeletons/CardButtonsSkeleton.vue
@@ -21,6 +21,7 @@
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardButtonsSkeleton',
 
   props: {

--- a/app/src/components/globals/skeletons/CardFormSkeleton.vue
+++ b/app/src/components/globals/skeletons/CardFormSkeleton.vue
@@ -4,8 +4,8 @@
       <BSkeleton width="30%" height="36px" class="m-0" />
     </template>
 
-    <template v-for="count in itemCount">
-      <BRow :key="count" :class="{ 'd-block': cols === null }">
+    <template v-for="count in itemCount" :key="count">
+      <BRow :class="{ 'd-block': cols === null }">
         <BCol v-bind="cols">
           <div style="height: 38px" class="d-flex align-items-center">
             <BSkeleton
@@ -32,7 +32,7 @@
         </BCol>
       </BRow>
 
-      <hr :key="count + '-hr'" />
+      <hr />
     </template>
 
     <template #footer>

--- a/app/src/components/globals/skeletons/CardFormSkeleton.vue
+++ b/app/src/components/globals/skeletons/CardFormSkeleton.vue
@@ -47,6 +47,7 @@
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardFormSkeleton',
 
   props: {

--- a/app/src/components/globals/skeletons/CardInfoSkeleton.vue
+++ b/app/src/components/globals/skeletons/CardInfoSkeleton.vue
@@ -19,6 +19,7 @@
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardInfoSkeleton',
 
   props: {

--- a/app/src/components/globals/skeletons/CardListSkeleton.vue
+++ b/app/src/components/globals/skeletons/CardListSkeleton.vue
@@ -23,6 +23,7 @@
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CardListSkeleton',
 
   props: {

--- a/app/src/components/globals/skeletons/ListGroupSkeleton.vue
+++ b/app/src/components/globals/skeletons/ListGroupSkeleton.vue
@@ -11,6 +11,7 @@
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ListGroupSkeleton',
 
   props: {

--- a/app/src/helpers/validators/customValidators.js
+++ b/app/src/helpers/validators/customValidators.js
@@ -1,70 +1,61 @@
-import { helpers } from 'vuelidate/lib/validators'
+import { helpers } from '@vuelidate/validators'
 
 // Unicode ranges are taken from https://stackoverflow.com/a/37668315
 const nonAsciiWordCharacters =
   '\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0561-\u0587\u05D0-\u05EA\u05F0-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u08A0-\u08B4\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E87\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA\u0EAB\u0EAD-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5\u1CF6\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u212F-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2183\u2184\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u2E2F\u3005\u3006\u3031-\u3035\u303B\u303C\u3041-\u3096\u309D-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FD5\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6E5\uA717-\uA71F\uA722-\uA788\uA78B-\uA7AD\uA7B0-\uA7B7\uA7F7-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB65\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC'
 
-const alphalownumdot_ = helpers.regex('alphalownumdot_', /^[a-z0-9_.]+$/)
+const alphalownumdot_ = helpers.regex(/^[a-z0-9_.]+$/)
 
 const domain = helpers.regex(
-  'domain',
   new RegExp(
     `^(?:[\\da-z${nonAsciiWordCharacters}]+(?:-*[\\da-z${nonAsciiWordCharacters}]+)*\\.)+(?:(?:xn--)?[\\da-z${nonAsciiWordCharacters}]{2,})$`,
   ),
 )
 
 const dynDomain = helpers.regex(
-  'dynDomain',
   new RegExp(`^(?:xn--)?[\\da-z-${nonAsciiWordCharacters}]+$`),
 )
 
-const emailLocalPart = helpers.regex('emailLocalPart', /^[\w.-]+$/)
+const emailLocalPart = helpers.regex(/^[\w.-]+$/)
 
-const emailForwardLocalPart = helpers.regex(
-  'emailForwardLocalPart',
-  /^[\w+.-]+$/,
-)
+const emailForwardLocalPart = helpers.regex(/^[\w+.-]+$/)
 
-const email = (value) =>
-  helpers.withParams({ type: 'email', value }, (value) => {
-    const [localPart, domainPart] = value.split('@')
-    if (!domainPart) return !helpers.req(value) || false
-    return (
-      !helpers.req(value) || (emailLocalPart(localPart) && domain(domainPart))
-    )
-  })(value)
+const email = (value) => {
+  const [localPart, domainPart] = value.split('@')
+  if (!domainPart) return !helpers.req(value) || false
+  return (
+    !helpers.req(value) || (emailLocalPart(localPart) && domain(domainPart))
+  )
+}
 
 // Same as email but with `+` allowed.
-const emailForward = (value) =>
-  helpers.withParams({ type: 'emailForward', value }, (value) => {
-    const [localPart, domainPart] = value.split('@')
-    if (!domainPart) return !helpers.req(value) || false
-    return (
-      !helpers.req(value) ||
-      (emailForwardLocalPart(localPart) && domain(domainPart))
-    )
-  })(value)
+const emailForward = (value) => {
+  const [localPart, domainPart] = value.split('@')
+  if (!domainPart) return !helpers.req(value) || false
+  return (
+    !helpers.req(value) ||
+    (emailForwardLocalPart(localPart) && domain(domainPart))
+  )
+}
 
 const appRepoUrl = helpers.regex(
-  'appRepoUrl',
   /^https:\/\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_./~]+\/[a-zA-Z0-9-_.]+_ynh(\/?(-\/)?tree\/[a-zA-Z0-9-_.]+)?(\.git)?\/?$/,
 )
 
-const includes = (items) => (item) =>
+const includes = (items) =>
   helpers.withParams(
-    { type: 'includes', value: item },
+    { type: 'includes' },
     (item) => !helpers.req(item) || (items ? items.includes(item) : false),
-  )(item)
+  )
 
 const name = helpers.regex(
-  'name',
   new RegExp(`^(?:[A-Za-z${nonAsciiWordCharacters}]{1,30}[ ,.'-]{0,3})+$`),
 )
 
-const unique = (items) => (item) =>
-  helpers.withParams({ type: 'unique', arg: items, value: item }, (item) =>
+const unique = (items) =>
+  helpers.withParams({ type: 'unique', arg: items }, (item) =>
     items ? !helpers.req(item) || !items.includes(item) : true,
-  )(item)
+  )
 
 export {
   alphalownumdot_,

--- a/app/src/helpers/validators/index.js
+++ b/app/src/helpers/validators/index.js
@@ -9,4 +9,4 @@ export {
   minValue,
   required,
   sameAs,
-} from 'vuelidate/lib/validators'
+} from '@vuelidate/validators'

--- a/app/src/helpers/yunohostArguments.js
+++ b/app/src/helpers/yunohostArguments.js
@@ -152,7 +152,7 @@ export function formatYunoHostArgument(arg) {
       props: defaultProps.concat(['type', 'autocomplete', 'trim']),
       callback: function () {
         if (!arg.help) {
-          arg.help = i18n.t('good_practices_about_admin_password')
+          arg.help = i18n.global.t('good_practices_about_admin_password')
         }
         arg.example = '••••••••••••'
         validation.passwordLenght = validators.minLength(8)
@@ -180,7 +180,7 @@ export function formatYunoHostArgument(arg) {
         if (arg.type !== 'select') {
           field.props.link = {
             name: arg.type + '-list',
-            text: i18n.t(`manage_${arg.type}s`),
+            text: i18n.global.t(`manage_${arg.type}s`),
           }
         }
       },
@@ -337,7 +337,7 @@ export function formatYunoHostArgument(arg) {
   if (arg.helpLink) {
     field.props.link = {
       href: arg.helpLink.href,
-      text: i18n.t(arg.helpLink.text),
+      text: i18n.global.t(arg.helpLink.text),
     }
   }
 

--- a/app/src/i18n/helpers.js
+++ b/app/src/i18n/helpers.js
@@ -90,9 +90,7 @@ export async function loadLocaleMessages(locale) {
 async function loadDateFnsLocale(locale) {
   const dateFnsLocaleName = supportedLocales[locale].dateFnsLocale || locale
   dateFnsLocale = (
-    await import(
-      `../../node_modules/date-fns/esm/locale/${dateFnsLocaleName}/index.js`
-    )
+    await import(`../../node_modules/date-fns/locale/${dateFnsLocaleName}.mjs`)
   ).default
 }
 

--- a/app/src/i18n/index.js
+++ b/app/src/i18n/index.js
@@ -3,10 +3,9 @@
  * @module i18n
  */
 
-import Vue from 'vue'
-import VueI18n from 'vue-i18n'
+import { createI18n } from 'vue-i18n'
 
-// Plugin Initialization
-Vue.use(VueI18n)
-
-export default new VueI18n({})
+export default createI18n({
+  // FIXME
+  legacy: true,
+})

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,7 +1,7 @@
 import { createApp, configureCompat } from 'vue'
 import App from './App.vue'
 import BootstrapVue from 'bootstrap-vue'
-import VueShowdown from 'vue-showdown'
+import { VueShowdownPlugin } from 'vue-showdown'
 
 import store from './store'
 import router from './router'
@@ -29,7 +29,8 @@ app.use(BootstrapVue, {
   BBadge: { pill: true },
 })
 
-app.use(VueShowdown, {
+app.use(VueShowdownPlugin, {
+  flavor: 'github',
   options: {
     emoji: true,
   },

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -20,6 +20,27 @@ app.use(i18n)
 
 configureCompat({
   MODE: 2,
+  // warnings we can do something about should be fixed
+  // next warnings are suppressed because those come from bootstrap-vue (vue2)
+  INSTANCE_EVENT_EMITTER: 'suppress-warning',
+  COMPONENT_FUNCTIONAL: 'suppress-warning',
+  RENDER_FUNCTION: 'suppress-warning',
+  GLOBAL_EXTEND: 'suppress-warning',
+  GLOBAL_MOUNT: 'suppress-warning',
+  WATCH_ARRAY: 'suppress-warning',
+  GLOBAL_PROTOTYPE: 'suppress-warning',
+  INSTANCE_SCOPED_SLOTS: 'suppress-warning',
+  INSTANCE_LISTENERS: 'suppress-warning',
+  OPTIONS_DATA_MERGE: 'suppress-warning',
+  OPTIONS_BEFORE_DESTROY: 'suppress-warning',
+  INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning',
+  CUSTOM_DIR: 'suppress-warning',
+  // TODO
+  // ATTR_FALSE_VALUE: 'suppress-warning',
+  // ATTR_ENUMERATED_COERCION
+  // ATTR_FALSE_VALUE
+  // COMPONENT_V_MODEL: 'suppress-warning',
+  // COMPILER_V_BIND_SYNC
 })
 
 // Styles are imported in `src/App.vue` <style>

--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -1,13 +1,9 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import routes from './routes'
 import store from '@/store'
 
-Vue.use(VueRouter)
-
-const router = new VueRouter({
-  // mode: 'history', // this allow all routes to be real ones (without '#')
-  base: import.meta.env.BASE_URL,
+const router = createRouter({
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes,
 
   scrollBehavior(to, from, savedPosition) {
@@ -22,7 +18,7 @@ const router = new VueRouter({
         setTimeout(() => resolve(savedPosition), 0)
       })
     } else {
-      return savedPosition || { x: 0, y: 0 }
+      return savedPosition || { left: 0, top: 0 }
     }
   },
 })

--- a/app/src/scss/font.scss
+++ b/app/src/scss/font.scss
@@ -6,90 +6,98 @@
   ╰─────────────────────────╯
 */
 
-/* firago-all-300-italic*/
+/* firago-latin-300-italic*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO ExtraLight Italic'),
-    url('~@fontsource/firago/files/firago-all-200-italic.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-200-italic.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-200-italic.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-200-italic.woff') format('woff');
   font-weight: 200;
   font-style: italic;
   font-display: swap;
 }
-/* firago-all-300-normal*/
+/* firago-latin-300-normal*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO ExtraLight'),
-    url('~@fontsource/firago/files/firago-all-200-normal.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-200-normal.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-200-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-200-normal.woff') format('woff');
   font-weight: 200;
   font-style: normal;
   font-display: swap;
 }
-/* firago-all-400-italic*/
+/* firago-latin-400-italic*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Italic'),
-    url('~@fontsource/firago/files/firago-all-400-italic.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-400-italic.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-400-italic.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-400-italic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
-/* firago-all-400-normal*/
+/* firago-latin-400-normal*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Regular'),
-    url('~@fontsource/firago/files/firago-all-400-normal.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-400-normal.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-400-normal.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
-/* firago-all-500-italic*/
+/* firago-latin-500-italic*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Medium Italic'),
-    url('~@fontsource/firago/files/firago-all-500-italic.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-500-italic.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-500-italic.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-500-italic.woff') format('woff');
   font-weight: 500;
   font-style: italic;
   font-display: swap;
 }
-/* firago-all-500-normal*/
+/* firago-latin-500-normal*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Medium'),
-    url('~@fontsource/firago/files/firago-all-500-normal.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-500-normal.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-500-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-500-normal.woff') format('woff');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
-/* firago-all-700-italic*/
+/* firago-latin-700-italic*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Bold Italic'),
-    url('~@fontsource/firago/files/firago-all-700-italic.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-700-italic.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-700-italic.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-700-italic.woff') format('woff');
   font-weight: 700;
   font-style: italic;
   font-display: swap;
 }
-/* firago-all-700-normal*/
+/* firago-latin-700-normal*/
 @font-face {
   font-family: 'FiraGO';
   src:
     local('FiraGO Bold'),
-    url('~@fontsource/firago/files/firago-all-700-normal.woff2') format('woff2'),
-    url('~@fontsource/firago/files/firago-all-700-normal.woff') format('woff');
+    url('~@fontsource/firago/files/firago-latin-700-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/firago/files/firago-latin-700-normal.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -103,13 +111,92 @@
   ╰───────────────────────────────╯
 */
 
+/* fira-code-cyrillic-ext-400-normal */
 @font-face {
   font-family: 'Fira Code';
-  src:
-    local('Fira Code Regular'),
-    // url('~@fontsource/fira-code/files/fira-code-all-400-normal.woff2') format('woff2'),
-    url('~@fontsource/fira-code/files/fira-code-all-400-normal.woff')
-      format('woff');
-  font-weight: 400;
   font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('~@fontsource/fira-code/files/fira-code-cyrillic-ext-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-cyrillic-ext-400-normal.woff')
+      format('woff');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
+    U+FE2E-FE2F;
+}
+
+/* fira-code-cyrillic-400-normal */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('~@fontsource/fira-code/files/fira-code-cyrillic-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-cyrillic-400-normal.woff')
+      format('woff');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* fira-code-greek-ext-400-normal */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('~@fontsource/fira-code/files/fira-code-greek-ext-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-greek-ext-400-normal.woff')
+      format('woff');
+  unicode-range: U+1F00-1FFF;
+}
+
+/* fira-code-greek-400-normal */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('~@fontsource/fira-code/files/fira-code-greek-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-greek-400-normal.woff')
+      format('woff');
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1,
+    U+03A3-03FF;
+}
+
+/* fira-code-latin-ext-400-normal */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('~@fontsource/fira-code/files/fira-code-latin-ext-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-latin-ext-400-normal.woff')
+      format('woff');
+  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF,
+    U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* fira-code-latin-400-normal */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    // local('Fira Code Regular'),
+    url('~@fontsource/fira-code/files/fira-code-latin-400-normal.woff2')
+      format('woff2'),
+    url('~@fontsource/fira-code/files/fira-code-latin-400-normal.woff')
+      format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/app/src/store/data.js
+++ b/app/src/store/data.js
@@ -1,5 +1,3 @@
-import Vue from 'vue'
-
 import api from '@/api'
 import { isEmptyValue } from '@/helpers/commons'
 import { stratify } from '@/helpers/data/tree'
@@ -34,7 +32,7 @@ export default {
     },
 
     SET_DOMAINS_DETAILS(state, [name, details]) {
-      Vue.set(state.domains_details, name, details)
+      state.domains_details[name] = details
     },
 
     UPDATE_DOMAINS_DETAILS(state, payload) {
@@ -43,9 +41,9 @@ export default {
     },
 
     DEL_DOMAINS_DETAILS(state, [name]) {
-      Vue.delete(state.domains_details, name)
+      delete state.domains_details[name]
       if (state.domains) {
-        Vue.delete(state.domains, name)
+        delete state.domains[name]
       }
     },
 
@@ -72,16 +70,16 @@ export default {
 
     ADD_USERS(state, [user]) {
       if (!state.users) state.users = {}
-      Vue.set(state.users, user.username, user)
+      state.users[user.username] = user
     },
 
     SET_USERS_DETAILS(state, [username, userData]) {
-      Vue.set(state.users_details, username, userData)
+      state.users_details[username] = userData
       if (!state.users) return
       const user = state.users[username]
       for (const key of ['fullname', 'mail']) {
         if (user[key] !== userData[key]) {
-          Vue.set(user, key, userData[key])
+          user[key] = userData[key]
         }
       }
     },
@@ -92,9 +90,9 @@ export default {
     },
 
     DEL_USERS_DETAILS(state, [username]) {
-      Vue.delete(state.users_details, username)
+      delete state.users_details[username]
       if (state.users) {
-        Vue.delete(state.users, username)
+        delete state.users[username]
         if (Object.keys(state.users).length === 0) {
           state.users = null
         }
@@ -107,16 +105,16 @@ export default {
 
     ADD_GROUPS(state, [{ name }]) {
       if (state.groups !== undefined) {
-        Vue.set(state.groups, name, { members: [], permissions: [] })
+        state.groups[name] = { members: [], permissions: [] }
       }
     },
 
     UPDATE_GROUPS(state, [data, { groupName }]) {
-      Vue.set(state.groups, groupName, data)
+      state.groups[groupName] = data
     },
 
     DEL_GROUPS(state, [groupname]) {
-      Vue.delete(state.groups, groupname)
+      delete state.groups[groupname]
     },
 
     SET_PERMISSIONS(state, [permissions]) {

--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -1,13 +1,10 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import { createStore } from 'vuex'
 
 import info from './info'
 import settings from './settings'
 import data from './data'
 
-Vue.use(Vuex)
-
-export default new Vuex.Store({
+export default createStore({
   state: settings.state,
   mutations: settings.mutations,
   actions: settings.actions,

--- a/app/src/store/info.js
+++ b/app/src/store/info.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import router from '@/router'
 import i18n from '@/i18n'
 import api from '@/api'
@@ -55,7 +54,7 @@ export default {
 
     UPDATE_REQUEST(state, { request, key, value }) {
       // This rely on data persistance and reactivity.
-      Vue.set(request, key, value)
+      request[key] = value
     },
 
     REMOVE_REQUEST(state, request) {
@@ -303,7 +302,7 @@ export default {
         // the ownership to stay generic.
         const request = error.request
         delete error.request
-        Vue.set(request, 'error', error)
+        request.error = error
         // Display the error in a modal on the current view.
         commit('SET_ERROR', request)
       }
@@ -330,7 +329,7 @@ export default {
 
     DISMISS_WARNING({ commit, state }, request) {
       commit('SET_WAITING', false)
-      Vue.delete(request, 'showWarningMessage')
+      delete request.showWarningMessage
     },
 
     UPDATE_ROUTER_KEY({ commit }, { to, from }) {

--- a/app/src/store/info.js
+++ b/app/src/store/info.js
@@ -153,6 +153,7 @@ export default {
     },
 
     DISCONNECT({ dispatch }, route = router.currentRoute) {
+      // FIXME vue3 currentRoute is now a ref (currentRoute.value)
       dispatch('RESET_CONNECTED')
       if (router.currentRoute.name === 'login') return
       router.push({

--- a/app/src/store/info.js
+++ b/app/src/store/info.js
@@ -199,7 +199,7 @@ export default {
         ? humanKey
         : { key: humanKey }
       const humanRoute = key
-        ? i18n.t('human_routes.' + key, args)
+        ? i18n.global.t('human_routes.' + key, args)
         : `[${method}] /${uri}`
 
       let request = {
@@ -368,9 +368,9 @@ export default {
         // if a traduction key string has been given and we also need to pass
         // the route param as a variable.
         if (trad && param) {
-          text = i18n.t(trad, { [param]: to.params[param] })
+          text = i18n.global.t(trad, { [param]: to.params[param] })
         } else if (trad) {
-          text = i18n.t(trad)
+          text = i18n.global.t(trad)
         } else {
           text = to.params[param]
         }
@@ -395,7 +395,7 @@ export default {
       }
 
       // Display a simplified breadcrumb as the document title.
-      document.title = `${getTitle(breadcrumb)} | ${i18n.t('yunohost_admin')}`
+      document.title = `${getTitle(breadcrumb)} | ${i18n.global.t('yunohost_admin')}`
     },
 
     UPDATE_TRANSITION_NAME({ state, commit }, { to, from }) {

--- a/app/src/store/settings.js
+++ b/app/src/store/settings.js
@@ -3,12 +3,7 @@
  * @module store/settings
  */
 
-import i18n from '@/i18n'
-import {
-  loadLocaleMessages,
-  updateDocumentLocale,
-  loadDateFnsLocale,
-} from '@/i18n/helpers'
+import { setI18nLocale, setI18nFallbackLocale } from '@/i18n/helpers'
 import supportedLocales from '@/i18n/supportedLocales'
 
 export default {
@@ -62,19 +57,14 @@ export default {
 
   actions: {
     UPDATE_LOCALE({ commit }, locale) {
-      loadLocaleMessages(locale).then(() => {
-        updateDocumentLocale(locale)
+      return setI18nLocale(locale).then(() => {
         commit('SET_LOCALE', locale)
-        i18n.locale = locale
       })
-      // also query the date-fns locale object for filters
-      loadDateFnsLocale(locale)
     },
 
     UPDATE_FALLBACKLOCALE({ commit }, locale) {
-      loadLocaleMessages(locale).then(() => {
+      return setI18nFallbackLocale(locale).then(() => {
         commit('SET_FALLBACKLOCALE', locale)
-        i18n.fallbackLocale = [locale, 'en']
       })
     },
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -16,6 +16,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'HomeView',
 
   data() {

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -102,7 +102,9 @@ export default {
             window.location.href = '/yunohost/admin/'
           } else {
             this.$router.push(
-              this.$router.currentRoute.query.redirect || { name: 'home' },
+              this.$router.currentRoute.value.query.redirect || {
+                name: 'home',
+              },
             )
           }
         })

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -39,6 +39,7 @@ import { useVuelidate } from '@vuelidate/core'
 import { alphalownumdot_, required, minLength } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'LoginView',
 
   props: {

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -2,7 +2,7 @@
   <CardForm
     :title="$t('login')"
     icon="lock"
-    :validation="$v"
+    :validation="v$"
     :server-error="serverError"
     @submit.prevent="login"
   >
@@ -10,14 +10,14 @@
     <FormField
       v-bind="fields.username"
       v-model="form.username"
-      :validation="$v.form.username"
+      :validation="v$.form.username"
     />
 
     <!-- ADMIN PASSWORD -->
     <FormField
       v-bind="fields.password"
       v-model="form.password"
-      :validation="$v.form.password"
+      :validation="v$.form.password"
     />
 
     <template #buttons>
@@ -35,16 +35,20 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 import { alphalownumdot_, required, minLength } from '@/helpers/validators'
 
 export default {
   name: 'LoginView',
 
-  mixins: [validationMixin],
-
   props: {
     forceReload: { type: Boolean, default: false },
+  },
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
   },
 
   data() {

--- a/app/src/views/PostInstall.vue
+++ b/app/src/views/PostInstall.vue
@@ -104,6 +104,7 @@ import {
 } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'PostInstall',
 
   components: {

--- a/app/src/views/PostInstall.vue
+++ b/app/src/views/PostInstall.vue
@@ -40,7 +40,7 @@
       <CardForm
         :title="$t('postinstall.user.title')"
         icon="user-plus"
-        :validation="$v"
+        :validation="v$"
         :server-error="serverError"
         :submit-text="$t('next')"
         @submit.prevent="setUser"
@@ -55,7 +55,7 @@
           :key="name"
           v-bind="field"
           v-model="user[name]"
-          :validation="$v.user[name]"
+          :validation="v$.user[name]"
         />
       </CardForm>
 
@@ -89,7 +89,7 @@
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import api from '@/api'
 import { DomainForm } from '@/views/_partials'
@@ -106,11 +106,15 @@ import {
 export default {
   name: 'PostInstall',
 
-  mixins: [validationMixin],
-
   components: {
     DomainForm,
     LoginView,
+  },
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
   },
 
   data() {
@@ -224,7 +228,7 @@ export default {
         username: { required, alphalownumdot_ },
         fullname: { required, name },
         password: { required, passwordLenght: minLength(8) },
-        confirmation: { required, passwordMatch: sameAs('password') },
+        confirmation: { required, passwordMatch: sameAs(this.user.password) },
       },
     }
   },

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -23,7 +23,7 @@
       {{ $t('domain.add.from_registrar') }}
     </BFormRadio>
 
-    <BCollapse id="collapse-domain" :visible.sync="domainIsVisible">
+    <BCollapse id="collapse-domain" v-model:visible="domainIsVisible">
       <p class="mt-2 alert alert-info">
         <YIcon iname="info-circle" />
         <span class="pl-1" v-html="$t('domain.add.from_registrar_desc')" />
@@ -50,7 +50,7 @@
       {{ $t('domain.add.from_yunohost') }}
     </BFormRadio>
 
-    <BCollapse id="collapse-dynDomain" :visible.sync="dynDomainIsVisible">
+    <BCollapse id="collapse-dynDomain" v-model:visible="dynDomainIsVisible">
       <p class="mt-2 alert alert-info">
         <YIcon iname="info-circle" />
         <span class="pl-1" v-html="$t('domain.add.from_yunohost_desc')" />
@@ -95,7 +95,7 @@
       {{ $t('domain.add.from_local') }}
     </BFormRadio>
 
-    <BCollapse id="collapse-localDomain" :visible.sync="localDomainIsVisible">
+    <BCollapse id="collapse-localDomain" v-model:visible="localDomainIsVisible">
       <p class="mt-2 alert alert-info">
         <YIcon iname="info-circle" />
         <span class="pl-1" v-html="$t('domain.add.from_local_desc')" />

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -3,7 +3,7 @@
     :title="title"
     icon="globe"
     :submit-text="submitText"
-    :validation="$v"
+    :validation="v$"
     :server-error="serverError"
     @submit.prevent="onSubmit"
   >
@@ -32,7 +32,7 @@
       <FormField
         v-bind="fields.domain"
         v-model="form.domain"
-        :validation="$v.form.domain"
+        :validation="v$.form.domain"
         class="mt-3"
       />
     </BCollapse>
@@ -58,7 +58,7 @@
 
       <FormField
         v-bind="fields.dynDomain"
-        :validation="$v.form.dynDomain"
+        :validation="v$.form.dynDomain"
         class="mt-3"
       >
         <template #default="{ self }">
@@ -68,13 +68,13 @@
 
       <FormField
         v-bind="fields.dynDomainPassword"
-        :validation="$v.form.dynDomainPassword"
+        :validation="v$.form.dynDomainPassword"
         v-model="form.dynDomainPassword"
       />
 
       <FormField
         v-bind="fields.dynDomainPasswordConfirmation"
-        :validation="$v.form.dynDomainPasswordConfirmation"
+        :validation="v$.form.dynDomainPasswordConfirmation"
         v-model="form.dynDomainPasswordConfirmation"
       />
     </BCollapse>
@@ -103,7 +103,7 @@
 
       <FormField
         v-bind="fields.localDomain"
-        :validation="$v.form.localDomain"
+        :validation="v$.form.localDomain"
         class="mt-3"
       >
         <template #default="{ self }">
@@ -116,7 +116,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import AdressInputSelect from '@/components/AdressInputSelect.vue'
 import { formatFormData } from '@/helpers/yunohostArguments'
@@ -135,6 +135,12 @@ export default {
     title: { type: String, required: true },
     submitText: { type: String, default: null },
     serverError: { type: String, default: '' },
+  },
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
   },
 
   data() {
@@ -261,8 +267,6 @@ export default {
       this.selected = 'domain'
     }
   },
-
-  mixins: [validationMixin],
 
   components: {
     AdressInputSelect,

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -129,6 +129,7 @@ import {
 } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DomainForm',
 
   props: {

--- a/app/src/views/_partials/ErrorDisplay.vue
+++ b/app/src/views/_partials/ErrorDisplay.vue
@@ -54,6 +54,7 @@
 import MessageListGroup from '@/components/MessageListGroup.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ErrorDisplay',
 
   components: {

--- a/app/src/views/_partials/HistoryConsole.vue
+++ b/app/src/views/_partials/HistoryConsole.vue
@@ -94,6 +94,7 @@ import QueryHeader from '@/components/QueryHeader.vue'
 import MessageListGroup from '@/components/MessageListGroup.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'HistoryConsole',
 
   components: {

--- a/app/src/views/_partials/ReconnectingDisplay.vue
+++ b/app/src/views/_partials/ReconnectingDisplay.vue
@@ -43,6 +43,7 @@ import api from '@/api'
 import LoginView from '@/views/LoginView.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ReconnectingDisplay',
 
   components: {

--- a/app/src/views/_partials/ViewLockOverlay.vue
+++ b/app/src/views/_partials/ViewLockOverlay.vue
@@ -74,23 +74,21 @@ export default {
     margin: 0 15%;
   }
 
-  ::v-deep {
-    .card-body {
-      padding: 1.5rem;
-      padding-bottom: 0;
-      max-height: 60vh;
-      overflow-y: auto;
+  :deep(.card-body) {
+    padding: 1.5rem;
+    padding-bottom: 0;
+    max-height: 60vh;
+    overflow-y: auto;
 
-      & > :last-child {
-        margin-bottom: 1.5rem;
-      }
+    & > :last-child {
+      margin-bottom: 1.5rem;
     }
+  }
 
-    .card-footer {
-      padding: 0.5rem 0.75rem;
-      display: flex;
-      justify-content: flex-end;
-    }
+  :deep(.card-footer) {
+    padding: 0.5rem 0.75rem;
+    display: flex;
+    justify-content: flex-end;
   }
 
   .card-header {

--- a/app/src/views/_partials/ViewLockOverlay.vue
+++ b/app/src/views/_partials/ViewLockOverlay.vue
@@ -30,6 +30,7 @@ import {
 import QueryHeader from '@/components/QueryHeader.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ViewLockOverlay',
 
   components: {

--- a/app/src/views/_partials/WaitingDisplay.vue
+++ b/app/src/views/_partials/WaitingDisplay.vue
@@ -30,6 +30,7 @@
 import MessageListGroup from '@/components/MessageListGroup.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'WaitingDisplay',
 
   components: {

--- a/app/src/views/_partials/WarningDisplay.vue
+++ b/app/src/views/_partials/WarningDisplay.vue
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'WarningDisplay',
 
   props: {

--- a/app/src/views/app/AppCatalog.vue
+++ b/app/src/views/app/AppCatalog.vue
@@ -514,7 +514,7 @@ export default {
 
     flex-basis: 90%;
 
-    .card-body {
+    :deep(.card-body) {
       display: flex;
       flex-direction: column;
       justify-content: center;

--- a/app/src/views/app/AppCatalog.vue
+++ b/app/src/views/app/AppCatalog.vue
@@ -171,7 +171,7 @@
         icon="download"
         @submit.prevent="onCustomInstallClick"
         :submit-text="$t('install')"
-        :validation="$v"
+        :validation="v$"
         class="mt-5"
       >
         <template #disclaimer>
@@ -185,7 +185,7 @@
         <FormField
           v-bind="customInstall.field"
           v-model="customInstall.url"
-          :validation="$v.customInstall.url"
+          :validation="v$.customInstall.url"
         />
       </CardForm>
     </template>
@@ -220,7 +220,7 @@
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import CardDeckFeed from '@/components/CardDeckFeed.vue'
 import { required, appRepoUrl } from '@/helpers/validators'
@@ -238,6 +238,12 @@ export default {
     quality: { type: String, default: 'decent_quality' },
     category: { type: String, default: null },
     subtag: { type: String, default: 'all' },
+  },
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
   },
 
   data() {
@@ -421,8 +427,6 @@ export default {
 
     randint,
   },
-
-  mixins: [validationMixin],
 }
 </script>
 

--- a/app/src/views/app/AppCatalog.vue
+++ b/app/src/views/app/AppCatalog.vue
@@ -227,6 +227,7 @@ import { required, appRepoUrl } from '@/helpers/validators'
 import { randint } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AppCatalog',
 
   components: {

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -377,6 +377,7 @@ import {
 import ConfigPanels from '@/components/ConfigPanels.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AppInfo',
 
   components: {

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -629,7 +629,9 @@ export default {
             Object.assign(this.externalResults, {
               forms: { [panel.id]: { [err.data.name]: [err.data.error] } },
             })
-          } else this.$set(panel, 'serverError', err.message)
+          } else {
+            panel.serverError = err.message
+          }
         })
     },
 

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -32,7 +32,6 @@
         v-for="[name, notif] in app.doc.notifications.postInstall"
         :key="name"
         :markdown="notif"
-        flavor="github"
         :options="{ headerLevelStart: 4 }"
       />
     </YAlert>
@@ -64,7 +63,6 @@
         v-for="[name, notif] in app.doc.notifications.postUpgrade"
         :key="name"
         :markdown="notif"
-        flavor="github"
         :options="{ headerLevelStart: 4 }"
       />
     </YAlert>
@@ -118,7 +116,7 @@
         </a>
       </p>
 
-      <VueShowdown :markdown="app.description" flavor="github" />
+      <VueShowdown :markdown="app.description" />
     </section>
 
     <YAlert v-if="config_panel_err" class="mb-4" variant="danger" icon="bug">
@@ -279,7 +277,7 @@
             <YIcon iname="book" class="mr-2" />
             {{ name === 'admin' ? $t('app.doc.admin.title') : name }}
           </template>
-          <VueShowdown :markdown="content" flavor="github" />
+          <VueShowdown :markdown="content" />
         </BTab>
       </BTabs>
     </BCard>

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -129,7 +129,7 @@
     <ConfigPanels
       v-bind="config"
       :external-results="externalResults"
-      @submit="onConfigSubmit"
+      @apply="onConfigSubmit"
     >
       <!-- OPERATIONS TAB -->
       <template v-if="currentTab === 'operations'" #tab-top>

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -27,7 +27,7 @@
           </template>
         </p>
 
-        <VueShowdown :markdown="app.description" flavor="github" />
+        <VueShowdown :markdown="app.description" />
 
         <BImg
           v-if="app.screenshot"
@@ -120,11 +120,7 @@
           v-t="'app.install.problems.lowquality'"
         />
 
-        <VueShowdown
-          v-if="app.preInstall"
-          :markdown="app.preInstall"
-          flavor="github"
-        />
+        <VueShowdown v-if="app.preInstall" :markdown="app.preInstall" />
       </YAlert>
 
       <YAlert

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -179,7 +179,7 @@
         :title="$t('app_install_parameters')"
         icon="cog"
         :submit-text="$t('install')"
-        :validation="$v"
+        :validation="v$"
         :server-error="serverError"
         @submit.prevent="performInstall"
       >
@@ -189,7 +189,7 @@
             :is="field.is"
             v-bind="field.props"
             v-model="form[fname]"
-            :validation="$v.form[fname]"
+            :validation="v$.form[fname]"
             :key="fname"
           />
         </template>
@@ -210,7 +210,7 @@
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import api, { objectToParams } from '@/api'
 import {
@@ -223,14 +223,18 @@ import CardCollapse from '@/components/CardCollapse.vue'
 export default {
   name: 'AppInstall',
 
-  mixins: [validationMixin],
-
   components: {
     CardCollapse,
   },
 
   props: {
     id: { type: String, required: true },
+  },
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
   },
 
   data() {

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -217,6 +217,7 @@ import {
 import CardCollapse from '@/components/CardCollapse.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AppInstall',
 
   components: {

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -186,8 +186,8 @@
         <template v-for="(field, fname) in fields">
           <Component
             v-if="field.visible"
-            :is="field.is"
             v-bind="field.props"
+            :is="field.is"
             v-model="form[fname]"
             :validation="v$.form[fname]"
             :key="fname"

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -39,6 +39,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'AppList',
 
   data() {

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -1,6 +1,6 @@
 <template>
   <ViewSearch
-    :search.sync="search"
+    v-model:search="search"
     items-name="installed_apps"
     :items="apps"
     :filtered-items="filteredApps"

--- a/app/src/views/backup/BackupCreate.vue
+++ b/app/src/views/backup/BackupCreate.vue
@@ -127,6 +127,7 @@
 import api from '@/api'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'BackupCreate',
 
   props: {

--- a/app/src/views/backup/BackupInfo.vue
+++ b/app/src/views/backup/BackupInfo.vue
@@ -142,6 +142,7 @@ import { humanSize } from '@/helpers/filters/human'
 import { isEmptyValue } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'BackupInfo',
 
   props: {

--- a/app/src/views/backup/BackupList.vue
+++ b/app/src/views/backup/BackupList.vue
@@ -49,6 +49,7 @@ import { distanceToNow, readableDate } from '@/helpers/filters/date'
 import { humanSize } from '@/helpers/filters/human'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'BackupList',
 
   props: {

--- a/app/src/views/backup/BackupView.vue
+++ b/app/src/views/backup/BackupView.vue
@@ -24,6 +24,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'BackupView',
 
   data() {

--- a/app/src/views/diagnosis/DiagnosisView.vue
+++ b/app/src/views/diagnosis/DiagnosisView.vue
@@ -153,6 +153,7 @@ import { distanceToNow } from '@/helpers/filters/date'
 import { DEFAULT_STATUS_ICON } from '@/helpers/yunohostArguments'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DiagnosisView',
 
   data() {

--- a/app/src/views/domain/DomainAdd.vue
+++ b/app/src/views/domain/DomainAdd.vue
@@ -14,6 +14,7 @@ import api from '@/api'
 import { DomainForm } from '@/views/_partials'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DomainAdd',
 
   data() {

--- a/app/src/views/domain/DomainDns.vue
+++ b/app/src/views/domain/DomainDns.vue
@@ -148,6 +148,7 @@ import api from '@/api'
 import { isEmptyValue } from '@/helpers/commons'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DomainDns',
 
   props: {

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -108,7 +108,12 @@
       </DescriptionRow>
     </YCard>
 
-    <ConfigPanels v-if="config.panels" v-bind="config" @submit="onConfigSubmit">
+    <ConfigPanels
+      v-if="config.panels"
+      v-bind="config"
+      :external-results="externalResults"
+      @submit="onConfigSubmit"
+    >
       <template v-if="currentTab === 'dns'" #tab-after>
         <DomainDns :name="name" />
       </template>
@@ -166,6 +171,7 @@ export default {
         ['GET', `domains/${this.name}/config?full`],
       ],
       config: {},
+      externalResults: {},
       unsubscribeDomainFromDyndns: false,
     }
   },
@@ -247,7 +253,9 @@ export default {
           if (err.name !== 'APIBadRequestError') throw err
           const panel = this.config.panels.find((panel) => panel.id === id)
           if (err.data.name) {
-            this.config.errors[id][err.data.name].message = err.message
+            Object.assign(this.externalResults, {
+              forms: { [panel.id]: { [err.data.name]: [err.data.error] } },
+            })
           } else this.$set(panel, 'serverError', err.message)
         })
     },

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -257,7 +257,9 @@ export default {
             Object.assign(this.externalResults, {
               forms: { [panel.id]: { [err.data.name]: [err.data.error] } },
             })
-          } else this.$set(panel, 'serverError', err.message)
+          } else {
+            panel.serverError = err.message
+          }
         })
     },
 

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -149,6 +149,7 @@ import ConfigPanels from '@/components/ConfigPanels.vue'
 import DomainDns from './DomainDns.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DomainInfo',
 
   components: {

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -112,7 +112,7 @@
       v-if="config.panels"
       v-bind="config"
       :external-results="externalResults"
-      @submit="onConfigSubmit"
+      @apply="onConfigSubmit"
     >
       <template v-if="currentTab === 'dns'" #tab-after>
         <DomainDns :name="name" />

--- a/app/src/views/domain/DomainList.vue
+++ b/app/src/views/domain/DomainList.vue
@@ -53,6 +53,7 @@ import { mapGetters } from 'vuex'
 import RecursiveListGroup from '@/components/RecursiveListGroup.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DomainList',
 
   components: {

--- a/app/src/views/domain/DomainList.vue
+++ b/app/src/views/domain/DomainList.vue
@@ -1,7 +1,7 @@
 <template>
   <ViewSearch
     id="domain-list"
-    :search.sync="search"
+    v-model:search="search"
     :items="domains"
     items-name="domains"
     :queries="queries"

--- a/app/src/views/group/GroupCreate.vue
+++ b/app/src/views/group/GroupCreate.vue
@@ -2,7 +2,7 @@
   <CardForm
     :title="$t('group_new')"
     icon="users"
-    :validation="$v"
+    :validation="v$"
     :server-error="serverError"
     @submit.prevent="onSubmit"
   >
@@ -10,19 +10,25 @@
     <FormField
       v-bind="groupname"
       v-model="form.groupname"
-      :validation="$v.form.groupname"
+      :validation="v$.form.groupname"
     />
   </CardForm>
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import api from '@/api'
 import { required, alphalownumdot_ } from '@/helpers/validators'
 
 export default {
   name: 'GroupCreate',
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
+  },
 
   data() {
     return {
@@ -63,7 +69,5 @@ export default {
         })
     },
   },
-
-  mixins: [validationMixin],
 }
 </script>

--- a/app/src/views/group/GroupCreate.vue
+++ b/app/src/views/group/GroupCreate.vue
@@ -22,6 +22,7 @@ import api from '@/api'
 import { required, alphalownumdot_ } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'GroupCreate',
 
   setup() {

--- a/app/src/views/group/GroupList.vue
+++ b/app/src/views/group/GroupList.vue
@@ -142,6 +142,7 @@ import TagsSelectizeItem from '@/components/globals/formItems/TagsSelectizeItem.
 // TODO add global search with type (search by: group, user, permission)
 // TODO add vuex store update on inputs ?
 export default {
+  compatConfig: { MODE: 3 },
   name: 'GroupList',
 
   components: {

--- a/app/src/views/group/GroupList.vue
+++ b/app/src/views/group/GroupList.vue
@@ -133,8 +133,6 @@
 </template>
 
 <script>
-import Vue from 'vue'
-
 import api from '@/api'
 import { isEmptyValue } from '@/helpers/commons'
 import TagsSelectizeItem from '@/components/globals/formItems/TagsSelectizeItem.vue'
@@ -325,7 +323,7 @@ export default {
           { key: 'groups.delete', name: groupName },
         )
         .then(() => {
-          Vue.delete(this.primaryGroups, groupName)
+          delete this.primaryGroups[groupName]
         })
     },
   },

--- a/app/src/views/group/GroupList.vue
+++ b/app/src/views/group/GroupList.vue
@@ -1,7 +1,7 @@
 <template>
   <ViewSearch
     items-name="groups"
-    :search.sync="search"
+    v-model:search="search"
     :items="primaryGroups"
     :filtered-items="filteredGroups"
     :queries="queries"

--- a/app/src/views/group/GroupList.vue
+++ b/app/src/views/group/GroupList.vue
@@ -96,8 +96,8 @@
       :title="$t('group_specific_permissions')"
       icon="group"
     >
-      <template v-for="(userName, index) in activeUserGroups">
-        <BRow :key="userName">
+      <template v-for="userName in activeUserGroups" :key="userName">
+        <BRow>
           <BCol md="3" lg="2">
             <YIcon iname="user" /> <strong>{{ userName }}</strong>
           </BCol>
@@ -116,7 +116,7 @@
             />
           </BCol>
         </BRow>
-        <hr :key="index" />
+        <hr />
       </template>
 
       <TagsSelectizeItem

--- a/app/src/views/service/ServiceInfo.vue
+++ b/app/src/views/service/ServiceInfo.vue
@@ -86,6 +86,7 @@ import api from '@/api'
 import { distanceToNow } from '@/helpers/filters/date'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ServiceInfo',
 
   props: {

--- a/app/src/views/service/ServiceInfo.vue
+++ b/app/src/views/service/ServiceInfo.vue
@@ -70,12 +70,12 @@
         </BButton>
       </template>
 
-      <template v-for="({ filename, content }, i) in logs">
-        <h3 :key="i + '-filename'">
+      <template v-for="{ filename, content } in logs" :key="filename">
+        <h3>
           {{ filename }}
         </h3>
 
-        <pre :key="i + '-content'" class="log"><code>{{ content }}</code></pre>
+        <pre class="log"><code>{{ content }}</code></pre>
       </template>
     </YCard>
   </ViewBase>

--- a/app/src/views/service/ServiceList.vue
+++ b/app/src/views/service/ServiceList.vue
@@ -46,6 +46,7 @@
 import { distanceToNow } from '@/helpers/filters/date'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ServiceList',
 
   data() {

--- a/app/src/views/service/ServiceList.vue
+++ b/app/src/views/service/ServiceList.vue
@@ -1,7 +1,7 @@
 <template>
   <ViewSearch
     id="service-list"
-    :search.sync="search"
+    v-model:search="search"
     :items="services"
     :filtered-items="filteredServices"
     items-name="services"

--- a/app/src/views/tool/ToolFirewall.vue
+++ b/app/src/views/tool/ToolFirewall.vue
@@ -56,7 +56,7 @@
     <CardForm
       :title="$t('operations')"
       icon="cogs"
-      :validation="$v"
+      :validation="v$"
       :server-error="serverError"
       @submit.prevent="onFormPortToggling"
       inline
@@ -66,7 +66,7 @@
         <BFormSelect v-model="form.action" :options="actionChoices" />
       </BInputGroup>
 
-      <FormField :validation="$v.form.port">
+      <FormField :validation="v$.form.port">
         <BInputGroup :prepend="$t('port')">
           <InputItem
             id="input-port"
@@ -119,13 +119,19 @@
 </template>
 
 <script>
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import api from '@/api'
 import { required, integer, between } from '@/helpers/validators'
 
 export default {
   name: 'ToolFirewall',
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
+  },
 
   data() {
     return {
@@ -281,8 +287,6 @@ export default {
       })
     },
   },
-
-  mixins: [validationMixin],
 }
 </script>
 

--- a/app/src/views/tool/ToolFirewall.vue
+++ b/app/src/views/tool/ToolFirewall.vue
@@ -125,6 +125,7 @@ import api from '@/api'
 import { required, integer, between } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolFirewall',
 
   setup() {

--- a/app/src/views/tool/ToolFirewall.vue
+++ b/app/src/views/tool/ToolFirewall.vue
@@ -270,13 +270,13 @@ export default {
     },
 
     onTablePortToggling(port, protocol, connection, index, value) {
-      this.$set(this.protocols[protocol][index], connection, value)
+      this.protocols[protocol][index][connection] = value
       const action = value ? 'allow' : 'disallow'
       this.togglePort({ action, port, protocol, connection }).then(
         (toggled) => {
           // Revert change on cancel
           if (!toggled) {
-            this.$set(this.protocols[protocol][index], connection, !value)
+            this.protocols[protocol][index][connection] = !value
           }
         },
       )

--- a/app/src/views/tool/ToolFirewall.vue
+++ b/app/src/views/tool/ToolFirewall.vue
@@ -291,7 +291,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .on-off-switch {
+:deep(.on-off-switch) {
   .custom-control-input {
     &:checked ~ .custom-control-label::before {
       border-color: $success;
@@ -322,7 +322,7 @@ export default {
   }
 }
 
-::v-deep form {
+:deep(form) {
   margin-bottom: -1rem;
 
   & > * {

--- a/app/src/views/tool/ToolList.vue
+++ b/app/src/views/tool/ToolList.vue
@@ -15,6 +15,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolList',
 
   data() {

--- a/app/src/views/tool/ToolLog.vue
+++ b/app/src/views/tool/ToolLog.vue
@@ -78,6 +78,7 @@ import { escapeHtml } from '@/helpers/commons'
 import { readableDate } from '@/helpers/filters/date'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolLog',
 
   props: {

--- a/app/src/views/tool/ToolLogs.vue
+++ b/app/src/views/tool/ToolLogs.vue
@@ -1,6 +1,6 @@
 <template>
   <ViewSearch
-    :search.sync="search"
+    v-model:search="search"
     :items="operations"
     :filtered-items="filteredOperations"
     items-name="logs"

--- a/app/src/views/tool/ToolLogs.vue
+++ b/app/src/views/tool/ToolLogs.vue
@@ -29,6 +29,7 @@
 import { distanceToNow, readableDate } from '@/helpers/filters/date'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolLogs',
 
   data() {

--- a/app/src/views/tool/ToolMigrations.vue
+++ b/app/src/views/tool/ToolMigrations.vue
@@ -91,6 +91,7 @@ import api from '@/api'
 
 // FIXME not tested with pending migrations (disclaimer and stuff)
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolMigrations',
 
   data() {

--- a/app/src/views/tool/ToolMigrations.vue
+++ b/app/src/views/tool/ToolMigrations.vue
@@ -112,7 +112,7 @@ export default {
       pending.forEach((migration) => {
         if (migration.disclaimer) {
           migration.disclaimer = migration.disclaimer.replaceAll('\n', '<br>')
-          this.$set(this.checked, migration.id, null)
+          this.checked[migration.id] = null
         }
       })
       // FIXME change to pending

--- a/app/src/views/tool/ToolPower.vue
+++ b/app/src/views/tool/ToolPower.vue
@@ -37,6 +37,7 @@
 import api from '@/api'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolPower',
 
   methods: {

--- a/app/src/views/tool/ToolSettings.vue
+++ b/app/src/views/tool/ToolSettings.vue
@@ -9,7 +9,7 @@
       v-if="config.panels"
       v-bind="config"
       :external-results="externalResults"
-      @submit="onConfigSubmit"
+      @apply="onConfigSubmit"
     />
   </ViewBase>
 </template>

--- a/app/src/views/tool/ToolSettings.vue
+++ b/app/src/views/tool/ToolSettings.vue
@@ -8,6 +8,7 @@
     <ConfigPanels
       v-if="config.panels"
       v-bind="config"
+      :external-results="externalResults"
       @submit="onConfigSubmit"
     />
   </ViewBase>
@@ -34,6 +35,7 @@ export default {
     return {
       queries: [['GET', 'settings?full']],
       config: {},
+      externalResults: {},
     }
   },
 
@@ -62,7 +64,9 @@ export default {
           if (err.name !== 'APIBadRequestError') throw err
           const panel = this.config.panels.find((panel) => panel.id === id)
           if (err.data.name) {
-            this.config.errors[id][err.data.name].message = err.message
+            Object.assign(this.externalResults, {
+              forms: { [panel.id]: { [err.data.name]: [err.data.error] } },
+            })
           } else this.$set(panel, 'serverError', err.message)
         })
     },

--- a/app/src/views/tool/ToolSettings.vue
+++ b/app/src/views/tool/ToolSettings.vue
@@ -23,6 +23,7 @@ import {
 import ConfigPanels from '@/components/ConfigPanels.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolSettingsConfig',
 
   components: {

--- a/app/src/views/tool/ToolSettings.vue
+++ b/app/src/views/tool/ToolSettings.vue
@@ -68,7 +68,9 @@ export default {
             Object.assign(this.externalResults, {
               forms: { [panel.id]: { [err.data.name]: [err.data.error] } },
             })
-          } else this.$set(panel, 'serverError', err.message)
+          } else {
+            panel.serverError = err.message
+          }
         })
     },
   },

--- a/app/src/views/tool/ToolWebadmin.vue
+++ b/app/src/views/tool/ToolWebadmin.vue
@@ -27,6 +27,7 @@ function mapStoreGetSet(props = [], action = 'commit') {
 }
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ToolWebadmin',
 
   data() {

--- a/app/src/views/tool/ToolWebadmin.vue
+++ b/app/src/views/tool/ToolWebadmin.vue
@@ -1,8 +1,8 @@
 <template>
   <CardForm :title="$t('tools_webadmin_settings')" icon="cog" no-footer>
-    <template v-for="(field, fname) in fields">
-      <FormField v-bind="field" v-model="self[fname]" :key="fname" />
-      <hr :key="fname + 'hr'" />
+    <template v-for="(field, fname) in fields" :key="fname">
+      <FormField v-bind="field" v-model="self[fname]" />
+      <hr />
     </template>
   </CardForm>
 </template>

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -144,6 +144,7 @@ import { mapGetters } from 'vuex'
 import CardCollapse from '@/components/CardCollapse.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SystemUpdate',
 
   components: {

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -127,7 +127,6 @@
             <BCardBody>
               <VueShowdown
                 :markdown="notif"
-                flavor="github"
                 :options="{ headerLevelStart: 6 }"
               />
             </BCardBody>

--- a/app/src/views/user/UserCreate.vue
+++ b/app/src/views/user/UserCreate.vue
@@ -84,6 +84,7 @@ import {
 } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'UserCreate',
 
   setup() {

--- a/app/src/views/user/UserCreate.vue
+++ b/app/src/views/user/UserCreate.vue
@@ -7,7 +7,7 @@
     <CardForm
       :title="$t('users_new')"
       icon="user-plus"
-      :validation="$v"
+      :validation="v$"
       :server-error="serverError"
       @submit.prevent="onSubmit"
     >
@@ -15,19 +15,19 @@
       <FormField
         v-bind="fields.username"
         v-model="form.username"
-        :validation="$v.form.username"
+        :validation="v$.form.username"
       />
 
       <!-- USER FULLNAME -->
       <FormField
         v-bind="fields.fullname"
-        :validation="$v.form.fullname"
+        :validation="v$.form.fullname"
         v-model="form.fullname"
       />
       <hr />
 
       <!-- USER MAIL DOMAIN -->
-      <FormField v-bind="fields.domain" :validation="$v.form.domain">
+      <FormField v-bind="fields.domain" :validation="v$.form.domain">
         <template #default="{ self }">
           <BInputGroup>
             <BInputGroupAppend>
@@ -55,14 +55,14 @@
       <FormField
         v-bind="fields.password"
         v-model="form.password"
-        :validation="$v.form.password"
+        :validation="v$.form.password"
       />
 
       <!-- USER PASSWORD CONFIRMATION -->
       <FormField
         v-bind="fields.confirmation"
         v-model="form.confirmation"
-        :validation="$v.form.confirmation"
+        :validation="v$.form.confirmation"
       />
     </CardForm>
   </ViewBase>
@@ -71,7 +71,7 @@
 <script>
 import api from '@/api'
 import { mapGetters } from 'vuex'
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import { formatFormData } from '@/helpers/yunohostArguments'
 import {
@@ -85,6 +85,12 @@ import {
 
 export default {
   name: 'UserCreate',
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
+  },
 
   data() {
     return {
@@ -164,7 +170,7 @@ export default {
         fullname: { required, name },
         domain: { required },
         password: { required, passwordLenght: minLength(8) },
-        confirmation: { required, passwordMatch: sameAs('password') },
+        confirmation: { required, passwordMatch: sameAs(this.form.password) },
       },
     }
   },
@@ -191,8 +197,6 @@ export default {
         })
     },
   },
-
-  mixins: [validationMixin],
 }
 </script>
 

--- a/app/src/views/user/UserEdit.vue
+++ b/app/src/views/user/UserEdit.vue
@@ -134,6 +134,7 @@ import {
 import AdressInputSelect from '@/components/AdressInputSelect.vue'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'UserEdit',
 
   props: {

--- a/app/src/views/user/UserImport.vue
+++ b/app/src/views/user/UserImport.vue
@@ -29,6 +29,7 @@ import { formatFormData } from '@/helpers/yunohostArguments'
 import { required } from '@/helpers/validators'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'UserImport',
 
   setup() {

--- a/app/src/views/user/UserImport.vue
+++ b/app/src/views/user/UserImport.vue
@@ -2,7 +2,7 @@
   <CardForm
     :title="$t('users_import')"
     icon="user-plus"
-    :validation="$v"
+    :validation="v$"
     :server-error="serverError"
     @submit.prevent="onSubmit"
   >
@@ -10,7 +10,7 @@
     <FormField
       v-bind="fields.csvfile"
       v-model="form.csvfile"
-      :validation="$v.form.csvfile"
+      :validation="v$.form.csvfile"
     />
 
     <!-- UPDATE -->
@@ -23,13 +23,19 @@
 
 <script>
 import api from '@/api'
-import { validationMixin } from 'vuelidate'
+import { useVuelidate } from '@vuelidate/core'
 
 import { formatFormData } from '@/helpers/yunohostArguments'
 import { required } from '@/helpers/validators'
 
 export default {
   name: 'UserImport',
+
+  setup() {
+    return {
+      v$: useVuelidate(),
+    }
+  },
 
   data() {
     return {
@@ -112,7 +118,5 @@ export default {
         })
     },
   },
-
-  mixins: [validationMixin],
 }
 </script>

--- a/app/src/views/user/UserInfo.vue
+++ b/app/src/views/user/UserInfo.vue
@@ -106,6 +106,7 @@
 import api from '@/api'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'UserInfo',
 
   props: {

--- a/app/src/views/user/UserList.vue
+++ b/app/src/views/user/UserList.vue
@@ -56,6 +56,7 @@
 import { mapGetters } from 'vuex'
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'UserList',
 
   data() {

--- a/app/src/views/user/UserList.vue
+++ b/app/src/views/user/UserList.vue
@@ -1,6 +1,6 @@
 <template>
   <ViewSearch
-    :search.sync="search"
+    v-model:search="search"
     :items="users"
     :filtered-items="filteredUsers"
     items-name="users"

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -68,9 +68,7 @@ export default defineConfig(({ command, mode }) => {
             }
             // Split date-fns locales
             if (id.includes('date-fns')) {
-              const match = /.*\/date-fns\/esm\/locale\/([\w-]+)\/.*\.js/.exec(
-                id,
-              )
+              const match = /.*\/date-fns\/locale\/([\w-]+)\/.*\.mjs/.exec(id)
               if (match) {
                 if (supportedDatefnsLocales.includes(match[1])) {
                   return `locales/${match[1]}/date-fns`

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,7 +1,7 @@
 import { fileURLToPath, URL } from 'url'
 import { defineConfig, loadEnv } from 'vite'
 import fs from 'fs'
-import vue from '@vitejs/plugin-vue2'
+import createVuePlugin from '@vitejs/plugin-vue'
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
@@ -15,6 +15,7 @@ export default defineConfig(({ command, mode }) => {
     },
     resolve: {
       alias: [
+        { find: 'vue', replacement: '@vue/compat' },
         // this is required for the SCSS modules imports with `~` (node_modules)
         { find: /^~(.*)$/, replacement: '$1' },
         {
@@ -33,7 +34,17 @@ export default defineConfig(({ command, mode }) => {
         },
       },
     },
-    plugins: [vue()],
+    plugins: [
+      createVuePlugin({
+        template: {
+          compilerOptions: {
+            compatConfig: {
+              MODE: 2,
+            },
+          },
+        },
+      }),
+    ],
     build: {
       rollupOptions: {
         output: {

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -25,7 +25,12 @@ export default defineConfig(({ command, mode }) => {
       alias: [
         { find: 'vue', replacement: '@vue/compat' },
         // this is required for the SCSS modules imports with `~` (node_modules)
-        { find: /^~(.*)$/, replacement: '$1' },
+        {
+          find: /^~(.*)$/,
+          replacement: fileURLToPath(
+            new URL('./node_modules/$1', import.meta.url),
+          ),
+        },
         {
           find: '@',
           replacement: fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
 First step for the migration to vue 3.
 
This make use of a compatibilty mode for vue that handle both vue2 and vue3 code. 
The app globally run with compat mode 2 but every individual component are on vue 3.
This is due to our component library `bootstrap-vue` which did not migrate to vue 3.

So this PR tries to migrate what can be done but there's still vue 2 legacy stuff around.

The next PR is a migration to `bootstrap-vue-next`, a vue3 fork in alpha.

## PR Status
Working i guess.

There are still some tests to do.

Should we do a big testing with bookworm or split the job in half? (on big release for bookworm and one big testing for vue3)

# How to test
Not sure yet if this PR should be tested itself, the migration to `bootstrap-vue-next` looks promising so we might focus directly on this one.