### PR TITLE
Allow plus on email

### DIFF
--- a/app/src/helpers/validators/customValidators.js
+++ b/app/src/helpers/validators/customValidators.js
@@ -18,7 +18,7 @@ const dynDomain = helpers.regex(
   new RegExp(`^(?:xn--)?[\\da-z-${nonAsciiWordCharacters}]+$`),
 )
 
-const emailLocalPart = helpers.regex('emailLocalPart', /^[\w.-]+$/)
+const emailLocalPart = helpers.regex('emailLocalPart', /^[\w+.-]+$/)
 
 const emailForwardLocalPart = helpers.regex(
   'emailForwardLocalPart',


### PR DESCRIPTION
The code does not allow a "+" on the email local part.
I think this is not the only one that missing:  https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.4