### PR TITLE
fix a weird sentence

### DIFF
--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -280,7 +280,7 @@
             },
             "push": "Push DNS records to registrar",
             "push_force": "Overwrite existing records",
-            "push_force_confirm": "Are you sure you want to force push all suggested dns records? Be aware that it may overwrite manually or important default records set by you or your registrar.",
+            "push_force_confirm": "Are you sure you want to force push all suggested dns records? Be aware that it may overwrite manual configuration or important default records set by you or your registrar.",
             "push_force_warning": "It looks like some DNS records that YunoHost would have set are already in the registrar configuration. You can use the overwrite option if you know what you are doing."
         },
         "explain": {


### PR DESCRIPTION
the sentence 
> Be aware that it may overwrite manually or important default records set by you or your registrar.

is really weird and confusing

i tried to fix it with:
> Be aware that it may overwrite **manual configuration** or important default records set by you or your registrar.