### PR TITLE
enh: subdomain addition + domain addition in app install

### DIFF
--- a/app/components.d.ts
+++ b/app/components.d.ts
@@ -93,6 +93,7 @@ declare module 'vue' {
     MarkdownItem: typeof import('./src/components/globals/formItems/MarkdownItem.vue')['default']
     MessageListGroup: typeof import('./src/components/MessageListGroup.vue')['default']
     ModalError: typeof import('./src/components/modals/ModalError.vue')['default']
+    ModalForm: typeof import('./src/components/globals/ModalForm.vue')['default']
     ModalOverlay: typeof import('./src/components/modals/ModalOverlay.vue')['default']
     ModalReconnecting: typeof import('./src/components/modals/ModalReconnecting.vue')['default']
     ModalWaiting: typeof import('./src/components/modals/ModalWaiting.vue')['default']

--- a/app/src/components/globals/ModalForm.vue
+++ b/app/src/components/globals/ModalForm.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts" generic="MV extends Obj, FFD extends FormFieldDict<MV>">
+import { createReusableTemplate } from '@vueuse/core'
+import { computed, toValue } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { FormValidation } from '@/composables/form'
+import { toEntries } from '@/helpers/commons'
+import type { KeyOfStr, Obj, VueClass } from '@/types/commons'
+import type { ConfigSection } from '@/types/configPanels'
+import type {
+  AnyDisplayComponents,
+  AnyWritableComponents,
+  BaseItemComputedProps,
+  ButtonItemProps,
+  FormFieldDict,
+} from '@/types/form'
+import { isDisplayComponent, isWritableComponent } from '@/types/form'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(
+  defineProps<{
+    id?: string
+    fields?: FFD
+    validations?: FormValidation<MV>
+    submitText?: string
+    inline?: boolean
+    formClasses?: VueClass
+    noFooter?: boolean
+    hr?: boolean
+    sections?: ConfigSection<MV, FFD>[]
+  }>(),
+  {
+    id: 'ynh-form',
+    fields: undefined,
+    validations: undefined,
+    submitText: undefined,
+    inline: false,
+    formClasses: undefined,
+    noFooter: false,
+    hr: false,
+    sections: undefined,
+  },
+)
+
+const emit = defineEmits<{
+  submit: [e: SubmitEvent]
+  action: [actionId: KeyOfStr<FFD>]
+  'update:modelValue': [modelValue: MV]
+}>()
+
+const slots = defineSlots<
+  {
+    top?: any
+    disclaimer?: any
+    'before-form'?: any
+    default?: any
+    'server-error'?: any
+    'after-form'?: any
+    buttons: any
+  } & {
+    [K in KeyOfStr<FFD> as `field:${K}`]?: (_: FFD[K]) => any
+  } & {
+    [K in KeyOfStr<FFD> as `component:${K}`]?: (
+      _: FFD[K]['component'] extends AnyWritableComponents
+        ? FFD[K]['cProps'] & BaseItemComputedProps
+        : FFD[K]['component'] extends AnyDisplayComponents
+          ? FFD[K]['cProps']
+          : never,
+    ) => any
+  }
+>()
+
+const modelValue = defineModel<MV>()
+const show = defineModel<boolean>('show')
+
+const { t } = useI18n()
+
+const globalErrorFeedback = computed(() => {
+  const v = props.validations
+  if (!v) return ''
+  const externalResults = toValue(v.global.$externalResults[0]?.$message)
+  return externalResults ?? (v.form.$error ? t('form_errors.invalid_form') : '')
+})
+
+const fields = computed(() => (props.fields ? toEntries(props.fields) : []))
+const sections = computed(() => {
+  const { sections, fields } = props
+  if (!sections || !fields) return
+  return sections.map((section) => ({
+    ...section,
+    fields: section.fields.map((id) => [id, fields[id]]) as {
+      [k in Extract<keyof FFD, string>]: [k, FFD[k]]
+    }[Extract<keyof FFD, string>][],
+  }))
+})
+
+function onModelUpdate(key: keyof MV, value: MV[keyof MV]) {
+  emit('update:modelValue', {
+    ...modelValue.value!,
+    [key]: value,
+  })
+}
+
+const Fields = createReusableTemplate<{
+  fieldsProps: { [k in Extract<keyof FFD, string>]: [k, FFD[k]] }[Extract<
+    keyof FFD,
+    string
+  >][]
+}>()
+
+// presence of <!-- @vue-expect-error --> are for `yarn type-check`,
+// don't know why custom component slots name doesn't pass
+</script>
+
+<template>
+  <Fields.define v-slot="{ fieldsProps }">
+    <template v-for="[k, field] in fieldsProps" :key="k">
+      <template v-if="toValue(field.visible) ?? true">
+        <!-- @vue-expect-error -->
+        <slot
+          v-if="isWritableComponent<MV[typeof k]>(field)"
+          :name="`field:${k}`"
+          v-bind="field"
+        >
+          <FormField
+            v-if="!field.readonly"
+            v-bind="field"
+            :model-value="modelValue![k]"
+            :validation="props.validations?.form[k]"
+            @update:model-value="onModelUpdate(k, $event)"
+          >
+            <!-- @vue-expect-error -->
+            <template v-if="slots[`component:${k}`]" #default="childProps">
+              <!-- @vue-expect-error -->
+              <slot :name="`component:${k}`" v-bind="childProps" />
+            </template>
+          </FormField>
+          <FormFieldReadonly
+            v-else
+            v-bind="field"
+            :model-value="modelValue![k]"
+          />
+        </slot>
+        <!-- @vue-expect-error -->
+        <slot
+          v-else-if="isDisplayComponent(field)"
+          :name="`component:${k}`"
+          v-bind="field.cProps"
+        >
+          <Component
+            :is="field.component"
+            v-if="field.component !== 'ButtonItem'"
+            v-bind="field.cProps"
+          />
+          <ButtonItem
+            v-else
+            v-bind="field.cProps as ButtonItemProps"
+            @action="emit('action', $event as KeyOfStr<FFD>)"
+          />
+        </slot>
+
+        <hr v-if="field.hr ?? hr" />
+      </template>
+    </template>
+  </Fields.define>
+
+  <BModal v-model="show" v-bind="$attrs" centered class="card-form">
+    <template #default>
+      <slot name="top" />
+
+      <slot name="disclaimer" />
+
+      <slot name="before-form" />
+
+      <BForm
+        :id="id"
+        :inline="inline"
+        :class="formClasses"
+        novalidate
+        @submit.prevent.stop="emit('submit', $event as SubmitEvent)"
+      >
+        <slot name="default">
+          <template v-if="sections">
+            <template v-for="section in sections" :key="section.id">
+              <Component
+                :is="section.name ? 'section' : 'div'"
+                v-if="toValue(section.visible)"
+                class="form-section"
+              >
+                <BCardTitle v-if="section.name" title-tag="h3">
+                  {{ section.name }}
+                  <small v-if="section.help">{{ section.help }}</small>
+                </BCardTitle>
+                <!-- @vue-ignore-next-line -->
+                <Fields.reuse :fields-props="section.fields" />
+              </Component>
+            </template>
+          </template>
+          <template v-else-if="fields">
+            <!-- @vue-ignore-next-line -->
+            <Fields.reuse :fields-props="fields" />
+          </template>
+        </slot>
+
+        <slot name="server-error">
+          <YAlert
+            v-if="globalErrorFeedback !== ''"
+            alert
+            variant="danger"
+            class="my-3"
+            icon="ban"
+          >
+            <div v-html="globalErrorFeedback" />
+          </YAlert>
+        </slot>
+      </BForm>
+
+      <slot name="after-form" />
+    </template>
+
+    <template #footer>
+      <BButton type="submit" variant="success" :form="id">
+        {{ submitText ?? $t('save') }}
+      </BButton>
+    </template>
+  </BModal>
+</template>

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -246,12 +246,15 @@
             "dyn_dns_password_desc": "This password will allow you to later recover control of the domain if you reinstall your system. If you already registered this domain previously, use your recovery password here to reclaim it.",
             "from_local": "I want a domain for local usage / test only",
             "from_local_desc": "If you don't want an \"actual\" public domain name, you can use anything ending in <code>.local</code> or <code>.test</code>. Domain names ending in <code>.local</code> are special in the sense that they may automatically be resolved on the local network, assuming the clients support the Bonjour protocol. Alternatively, you may need to tweak the <code>/etc/hosts</code> file (or equivalent on Windows) on every client that you want to use this domain from, or to configure local DNS entries on your internet router.",
-            "from_registrar": "I want to add a domain I own, or a subdomain",
+            "from_registrar": "I want to add a domain I own",
             "from_registrar_desc": "You will need to manually configure DNS records on your registrar to finalize this domain's configuration. YunoHost's diagnosis will guide you about what DNS records to configure exactly.",
+            "from_subdomain": "I want to add a subdomain of an already added domain",
+            "from_subdomain_desc": "If your configured DNS records allows it, you will be able to automaticly install Let's Encrypt certificate.",
             "from_yunohost": "I don't own a domain, I want to register/use a free DynDNS domain provided by the YunoHost project",
             "from_yunohost_desc": "The YunoHost project maintains a free 'DynDNS' service. It is limited to one such domain per server (though you can also add sub-domains later using the other 'Add a domain I own, or a subdomain' option above). The DNS configuration will be automatically handled by YunoHost. This is ideal when starting up with self-hosting in general and you don't want to invest in a domain name yet. However, on the medium/long-term, we recommend buying your very own domain name to some registrar to have full ownership of your domain."
         },
         "cert": {
+            "install": "Also install Let's Encrypt certificate",
             "types": {
                 "letsencrypt": "Let's Encrypt",
                 "other": "Other/Unknown",

--- a/app/src/types/core/api.ts
+++ b/app/src/types/core/api.ts
@@ -1,4 +1,4 @@
-import type { Obj, Translation } from '@/types/commons'
+import type { Obj, StateVariant, Translation } from '@/types/commons'
 import type { Permission } from '@/types/core/data'
 import type { AnyOption } from '@/types/core/options'
 
@@ -330,3 +330,14 @@ export type DNSCategories = Record<
   'create' | 'update' | 'delete' | 'unchanged',
   DNSRecord[]
 >
+
+export type Certificate = {
+  subject: string
+  CA_name: string
+  CA_type: 'selfsigned' | 'letsencrypt' | 'other'
+  validity: number
+  style: Exclude<StateVariant, 'info'>
+  summary: string // enum
+  ACME_eligible: boolean
+  has_wildcards: boolean
+}

--- a/app/src/types/core/data.ts
+++ b/app/src/types/core/data.ts
@@ -1,4 +1,4 @@
-import type { StateVariant } from '@/types/commons'
+import type { Certificate } from '@/types/core/api'
 
 export type UserItem = {
   username: string
@@ -30,15 +30,7 @@ export type Group = {
   permissions: string[]
 }
 export type DomainDetail = {
-  certificate: {
-    subject: string
-    CA_name: string
-    CA_type: 'selfsigned' | 'letsencrypt' | 'other'
-    validity: number
-    style: Exclude<StateVariant, 'info'>
-    summary: string // enum
-    ACME_eligible: boolean
-  }
+  certificate: Certificate
   registrar: string // or null ?
   apps: { name: string; id: string; path: string }[]
   main: boolean

--- a/app/src/views/PostInstall.vue
+++ b/app/src/views/PostInstall.vue
@@ -168,10 +168,10 @@ async function performPostInstall(force = false) {
     <!-- DOMAIN SETUP STEP -->
     <template v-else-if="step === 'domain'">
       <DomainForm
-        :domains="[]"
-        :title="$t('postinstall_set_domain')"
+        postinstall
         :submit-text="$t('next')"
         :server-error="serverError"
+        :title="$t('postinstall_set_domain')"
         @submit="setDomain"
       >
         <template #disclaimer>

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -22,11 +22,13 @@ defineOptions({
 const props = withDefaults(
   defineProps<{
     title: string
+    modal?: boolean
     postinstall?: boolean
     submitText?: string
     serverError?: string
   }>(),
   {
+    modal: false,
     postinstall: false,
     submitText: undefined,
     serverError: undefined,
@@ -41,6 +43,8 @@ const emit = defineEmits<{
     },
   ]
 }>()
+
+const show = defineModel<boolean>('show')
 
 const { domains, domainsAsChoices } = !props.postinstall
   ? useDomains()
@@ -249,7 +253,10 @@ const onDomainAdd = onSubmit(async () => {
 </script>
 
 <template>
-  <CardForm
+  <Component
+    :is="modal ? 'ModalForm' : 'CardForm'"
+    id="domain-add"
+    v-model:show="show"
     :title="title"
     icon="globe"
     :submit-text="submitText"
@@ -379,5 +386,5 @@ const onDomainAdd = onSubmit(async () => {
         :validation="v.form.localDomain"
       />
     </BCollapse>
-  </CardForm>
+  </Component>
 </template>

--- a/app/src/views/_partials/DomainForm.vue
+++ b/app/src/views/_partials/DomainForm.vue
@@ -2,6 +2,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useDomains } from '@/composables/data'
 import { useForm } from '@/composables/form'
 import {
   domain,
@@ -19,12 +20,13 @@ defineOptions({
 
 const props = withDefaults(
   defineProps<{
-    domains: string[]
     title: string
+    postinstall?: boolean
     submitText?: string
     serverError?: string
   }>(),
   {
+    postinstall: false,
     submitText: undefined,
     serverError: undefined,
   },
@@ -33,12 +35,16 @@ const emit = defineEmits<{
   submit: [data: { domain: string; dyndns_recovery_password?: string }]
 }>()
 
+const { domains, domainsAsChoices } = !props.postinstall
+  ? useDomains()
+  : { domains: ref([] as string[]), domainsAsChoices: ref([] as string[]) }
+
 const { t } = useI18n()
 const dynDomains = ['nohost.me', 'noho.st', 'ynh.fr']
 
 const dynDnsForbiden = computed(() => {
-  if (!props.domains) return false
-  return props.domains.some((domain) => {
+  if (!domains.value) return false
+  return domains.value.some((domain) => {
     return dynDomains.some((dynDomain) => domain.includes(dynDomain))
   })
 })

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -4,13 +4,17 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 import api, { objectToParams } from '@/api'
+import { APIBadRequestError, APIError } from '@/api/errors'
 import { formatOptions } from '@/composables/configPanels'
+import { useDomains } from '@/composables/data'
 import { useForm } from '@/composables/form'
 import { useAutoModal } from '@/composables/useAutoModal'
 import { getKeys, joinOrNull } from '@/helpers/commons'
 import { formatForm, formatI18nField } from '@/helpers/yunohostArguments'
 import type { Obj } from '@/types/commons'
 import type { AppManifest, Catalog } from '@/types/core/api'
+import type { FormFieldProps } from '@/types/form'
+import DomainForm from '@/views/_partials/DomainForm.vue'
 import {
   formatAppIntegration,
   formatAppLinks,
@@ -88,8 +92,11 @@ const [app, form, fields] = await api
     return [app, form, fields] as const
   })
 
+const { domainsAsChoices } = useDomains()
 const { v, onSubmit } = useForm(form, fields)
 const force = ref(false)
+const showAddDomainModal = ref(false)
+const domainAddServerError = ref('')
 
 const performInstall = onSubmit(async (onError) => {
   if ('path' in form.value && form.value.path === '/') {
@@ -131,6 +138,28 @@ const performInstall = onSubmit(async (onError) => {
     })
     .catch(onError)
 })
+
+function onDomainAdd(data: {
+  domain: string
+  dyndns_recovery_password?: string
+  install_letsencrypt_cert?: boolean
+}) {
+  api
+    .post({
+      uri: 'domains',
+      cachePath: `domains.${data.domain}`,
+      data,
+      humanKey: { key: 'domains.add', name: data.domain },
+    })
+    .then(() => {
+      form.value.domain = data.domain
+      showAddDomainModal.value = false
+    })
+    .catch((err: APIError) => {
+      if (!(err instanceof APIBadRequestError)) throw err
+      domainAddServerError.value = err.message
+    })
+}
 </script>
 
 <template>
@@ -260,8 +289,36 @@ const performInstall = onSubmit(async (onError) => {
         :submit-text="$t('install')"
         :validations="v"
         @submit="performInstall"
-      />
+      >
+        <template v-if="form.domain" #field:domain="fieldProps">
+          <FormField
+            v-bind="fieldProps as FormFieldProps<'SelectItem', string>"
+          >
+            <template #default="componentProps">
+              <BInputGroup>
+                <SelectItem
+                  v-bind="componentProps"
+                  v-model="form.domain"
+                  :options="domainsAsChoices"
+                />
+                <BButton variant="primary" @click="showAddDomainModal = true">
+                  {{ t('domain_add') }}
+                </BButton>
+              </BInputGroup>
+            </template>
+          </FormField>
+        </template>
+      </CardForm>
     </template>
+
+    <DomainForm
+      v-model:show="showAddDomainModal"
+      modal
+      :submit-text="$t('add')"
+      :server-error="domainAddServerError"
+      :title="$t('domain_add')"
+      @submit="onDomainAdd"
+    />
 
     <!-- FIXME hum not handled, is it still a thing? -->
     <!-- In case of a custom url with no manifest found -->

--- a/app/src/views/domain/DomainAdd.vue
+++ b/app/src/views/domain/DomainAdd.vue
@@ -10,7 +10,11 @@ const router = useRouter()
 
 const serverError = ref('')
 
-function onSubmit(data: { domain: string; dyndns_recovery_password?: string }) {
+function onSubmit(data: {
+  domain: string
+  dyndns_recovery_password?: string
+  install_letsencrypt_cert?: boolean
+}) {
   api
     .post({
       uri: 'domains',

--- a/app/src/views/domain/DomainAdd.vue
+++ b/app/src/views/domain/DomainAdd.vue
@@ -4,14 +4,10 @@ import { useRouter } from 'vue-router'
 
 import api from '@/api'
 import { APIBadRequestError, type APIError } from '@/api/errors'
-import { useDomains } from '@/composables/data'
 import { DomainForm } from '@/views/_partials'
 
 const router = useRouter()
 
-await api.fetch({ uri: 'domains', cachePath: 'domains' })
-
-const { domains } = useDomains()
 const serverError = ref('')
 
 function onSubmit(data: { domain: string; dyndns_recovery_password?: string }) {
@@ -34,7 +30,6 @@ function onSubmit(data: { domain: string; dyndns_recovery_password?: string }) {
 
 <template>
   <DomainForm
-    :domains="domains"
     :title="$t('domain_add')"
     :server-error="serverError"
     :submit-text="$t('add')"


### PR DESCRIPTION
## The problem
- sometimes you just want to add a subdomain, being able to just enter the subpath with your already added domain is less error prone.
- in AppInstall view you are sometimes required to add a specific subdomain for an app, having to return to DomainAdd to setup said new domain then run the diagnosis or force install a Let's Encrypt certificate is tedious.

## Solution
- add subdomain option to DomainForm with ability to auto install the Let's encrypt certificate if a wildcard is detected in DNS records
- add ability to add a domain/subdomain directly in the AppInstall view in the `domain` field, as a modal, with auto select of the newly added domain.

## PR Status
could'nt test the letsencrypt install properly (can't install certs on my setup idk why)

Requires: https://github.com/YunoHost/yunohost/pull/1936
Fix: https://github.com/YunoHost/issues/issues/1634

## Preview 

![image](https://github.com/user-attachments/assets/24f366c1-957f-4c02-ac9a-4d194a8f36ad)
![image](https://github.com/user-attachments/assets/bdb32c53-ac7a-463d-bde9-a80611ab2b39)

