### PR TITLE
Enh: Make auto dns feature optional

### DIFF
--- a/app/src/views/domain/DomainDns.vue
+++ b/app/src/views/domain/DomainDns.vue
@@ -104,7 +104,7 @@ function getDnsChanges() {
           { icon: 'ban', variant: 'danger', message: err.data.error },
         ]
       } else {
-        showManualConfigCard.value = true
+        showManualConfigCard.value = key !== 'domain_dns_conf_special_use_tld'
         showAutoConfigCard.value = false
       }
     })

--- a/app/src/views/domain/DomainDns.vue
+++ b/app/src/views/domain/DomainDns.vue
@@ -17,6 +17,7 @@ type DNSError = { icon: string; variant: StateVariant; message: string }
 
 const props = defineProps<{
   name: string
+  autoDns: boolean
 }>()
 
 const { t } = useI18n()
@@ -95,6 +96,13 @@ function getDnsChanges() {
       } else if (key === 'domain_dns_push_failed_to_authenticate') {
         const message = t(key, err.data)
         dnsErrors.value = [{ icon: 'ban', variant: 'danger', message }]
+      } else if (
+        key === 'domain_registrar_is_not_configured' &&
+        props.autoDns
+      ) {
+        dnsErrors.value = [
+          { icon: 'ban', variant: 'danger', message: err.data.error },
+        ]
       } else {
         showManualConfigCard.value = true
         showAutoConfigCard.value = false
@@ -192,7 +200,7 @@ async function pushDnsChanges() {
 
       <!-- CONFIG OK ALERT -->
       <ReadOnlyAlertItem
-        v-else-if="dnsChanges === null"
+        v-else-if="dnsChanges === null && !dnsErrors.length"
         :label="$t('domain.dns.auto_config_ok')"
         type="success"
         icon="thumbs-up"

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -226,7 +226,7 @@ async function setAsDefaultDomain() {
       @apply="config.onPanelApply"
     >
       <template v-if="tabId === 'dns'" #tab-after>
-        <DomainDns :name="name" />
+        <DomainDns :name="name" :auto-dns="config.form.value.use_auto_dns" />
       </template>
     </ConfigPanelsComponent>
 


### PR DESCRIPTION
## The problem
- we display suggested DNS records for special-use domains
- since auth infos for auto DNS push feature are now optional, there's no errors for misconfigured registrar. 

## Solution

- display error when the feature is activated
- hide suggested DNS records for special-use domains
- do not show that the auto dns are ok when they're not :/

## PR Status
OK

Requires: https://github.com/YunoHost/yunohost/pull/1951
