### PR TITLE
refactor: move group/perms link to home directly

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 const menu = [
   { routeName: 'user-list', icon: 'users', translation: 'users' },
+  {
+    routeName: 'group-list',
+    icon: 'key-modern',
+    translation: 'groups_and_permissions',
+  },
   { routeName: 'domain-list', icon: 'globe', translation: 'domains' },
   { routeName: 'app-list', icon: 'cubes', translation: 'applications' },
   { routeName: 'update', icon: 'refresh', translation: 'system_update' },

--- a/app/src/views/user/UserList.vue
+++ b/app/src/views/user/UserList.vue
@@ -25,10 +25,6 @@ function downloadExport() {
 <template>
   <ViewSearch v-model="search" :items="filteredUsers" items-name="users">
     <template #top-bar-buttons>
-      <BButton variant="info" :to="{ name: 'group-list' }">
-        <YIcon iname="key-modern" /> {{ $t('groups_and_permissions_manage') }}
-      </BButton>
-
       <BDropdown
         :split-to="{ name: 'user-create' }"
         split


### PR DESCRIPTION
Simply move Groups and permission link from UserList to Home

![image](https://github.com/user-attachments/assets/45acce50-e1d4-4e43-9d92-91516667b6a0)
