### PR TITLE
Properly remove mailbox quota

### DIFF
--- a/app/src/views/user/UserEdit.vue
+++ b/app/src/views/user/UserEdit.vue
@@ -197,7 +197,7 @@ const onUserEdit = onSubmit(async (onError, serverErrors) => {
     if (key === 'mail_aliases' || key === 'mail_forward') return
     if (key === 'mailbox_quota') {
       if (formData[key] !== mailboxQuota) {
-        data[key] = formData[key]! > 0 ? formData[key] + 'M' : 'No quota'
+        data[key] = formData[key]! > 0 ? formData[key] + 'M' : '0'
       }
     } else if (key === 'change_password') {
       data.change_password = formData[key]


### PR DESCRIPTION
Currently editing user, when one enters `0` as mailbox quota posts back to the API

```
Content-Disposition: form-data; name="mailbox_quota"

No quota
```

This however does not pass validation rules imposed in [actionsmap.yml](https://github.com/YunoHost/yunohost/blob/4e9d94c836fa34b37805bf07b61aa8aa0d9d61e3/share/actionsmap.yml#L101C37-L101C53) hence the request fails.

This posts back value of `0` which is the expected result.