### PR TITLE
app/permissions: Move permissions data out of LDAP, introduce a new 'app core' config panel allowing to change the app logo, label, etc.

### DIFF
--- a/app/components.d.ts
+++ b/app/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     BButtonToolbar: typeof import('bootstrap-vue-next/components/BButton')['BButtonToolbar']
     BCard: typeof import('bootstrap-vue-next/components/BCard')['BCard']
     BCardBody: typeof import('bootstrap-vue-next/components/BCard')['BCardBody']
+    BCardFooter: typeof import('bootstrap-vue-next/components/BCard')['BCardFooter']
     BCardGroup: typeof import('bootstrap-vue-next/components/BCard')['BCardGroup']
     BCardHeader: typeof import('bootstrap-vue-next/components/BCard')['BCardHeader']
     BCardText: typeof import('bootstrap-vue-next/components/BCard')['BCardText']

--- a/app/src/components/ConfigPanels.vue
+++ b/app/src/components/ConfigPanels.vue
@@ -3,6 +3,7 @@
   lang="ts"
   generic="NestedMV extends Obj, MV extends Obj<NestedMV>"
 >
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import type { FormValidation } from '@/composables/form'
@@ -32,58 +33,59 @@ const slots = defineSlots<{
 }>()
 
 const modelValue = defineModel<NestedMV>({ required: true })
+
+const cardProps = computed(() => {
+  const { text, icon } = _props.routes[0]
+  return _props.routes.length === 1 ? { title: text, icon } : {}
+})
 </script>
 
 <template>
-  <BCard v-if="routes.length > 1" no-body class="config-panel">
-    <BCardHeader tag="nav">
-      <BNav card-header fill pills>
-        <BNavItem
-          v-for="route in routes"
-          :key="route.text"
-          :to="route.to"
-          :active="currentRoute.params.tabId === route.to.params?.tabId"
-        >
-          <!-- FIXME added :active="" because `exact-active-class` not working https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1754 -->
-          <!-- exact-active-class="active" -->
-          <YIcon v-if="route.icon" :iname="route.icon" />
-          {{ route.text }}
-        </BNavItem>
-      </BNav>
-    </BCardHeader>
+  <CardForm
+    v-bind="cardProps"
+    :key="panel.id"
+    :id="`panel-${panel.id}`"
+    v-model="modelValue"
+    :fields="panel.fields"
+    :no-footer="!panel.hasApplyButton"
+    :sections="panel.sections"
+    :validations="validations"
+    @submit="emit('apply')"
+    @action="emit('apply', $event)"
+    class="config-panel"
+  >
+    <template v-if="routes.length > 1" #header>
+      <BCardHeader tag="nav">
+        <BNav card-header fill pills>
+          <BNavItem
+            v-for="route in routes"
+            :key="route.text"
+            :to="route.to"
+            :active="currentRoute.params.tabId === route.to.params?.tabId"
+          >
+            <!-- FIXME added :active="" because `exact-active-class` not working https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1754 -->
+            <!-- exact-active-class="active" -->
+            <YIcon v-if="route.icon" :iname="route.icon" />
+            {{ route.text }}
+          </BNavItem>
+        </BNav>
+      </BCardHeader>
+    </template>
 
-    <CardForm
-      :key="panel.id"
-      v-model="modelValue"
-      :fields="panel.fields"
-      :no-footer="!panel.hasApplyButton"
-      :sections="panel.sections"
-      :validations="validations"
-      as-tab
-      @submit="emit('apply')"
-      @action="emit('apply', $event)"
-    >
-      <template #top>
-        <slot name="tab-top" />
-      </template>
-      <template v-if="panel.help" #disclaimer>
-        <div class="alert alert-info" v-html="panel.help" />
-      </template>
-      <template #before-form>
-        <slot name="tab-before" />
-      </template>
-      <template v-if="slots.default" #default>
-        <slot name="default" />
-      </template>
-      <template #after-form>
-        <slot name="tab-after" />
-      </template>
-    </CardForm>
-  </BCard>
-  <YCard v-else :title="routes[0].text" :icon="routes[0].icon">
-    <slot name="tab-top" />
-    <slot name="tab-before" />
-    <slot name="default" />
-    <slot name="tab-after" />
-  </YCard>
+    <template #top>
+      <slot name="tab-top" />
+    </template>
+    <template v-if="panel.help" #disclaimer>
+      <div class="alert alert-info" v-html="panel.help" />
+    </template>
+    <template #before-form>
+      <slot name="tab-before" />
+    </template>
+    <template v-if="slots.default" #default>
+      <slot name="default" />
+    </template>
+    <template #after-form>
+      <slot name="tab-after" />
+    </template>
+  </CardForm>
 </template>

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -174,7 +174,7 @@ const Fields = createReusableTemplate<{
       </BCardHeader>
     </slot>
 
-    <BCardBody>
+    <BCardBody class="p-0">
       <slot name="top" />
 
       <slot name="disclaimer" />
@@ -188,26 +188,35 @@ const Fields = createReusableTemplate<{
         @submit.prevent.stop="emit('submit', $event as SubmitEvent)"
       >
         <slot name="default">
-          <template v-if="sections">
+          <BAccordion v-if="sections" flush free>
             <template v-for="section in sections" :key="section.id">
-              <Component
-                :is="section.name ? 'section' : 'div'"
-                v-if="toValue(section.visible)"
+              <BAccordionItem
+                v-if="section.name && section.visible"
+                header-tag="h3"
+                :visible="!section.collapsed"
                 class="form-section"
               >
-                <BCardTitle v-if="section.name" title-tag="h3">
-                  {{ section.name }}
-                  <small v-if="section.help">{{ section.help }}</small>
-                </BCardTitle>
+                <template #title>
+                  <span class="fs-3">{{ section.name }}</span>
+                  <small v-if="section.help" class="ms-1 text-secondary">
+                    {{ section.help }}
+                  </small>
+                </template>
+                <div>
+                  <!-- @vue-ignore-next-line -->
+                  <Fields.reuse :fields-props="section.fields" />
+                </div>
+              </BAccordionItem>
+              <div v-else-if="section.visible" class="form-section p-3">
                 <!-- @vue-ignore-next-line -->
                 <Fields.reuse :fields-props="section.fields" />
-              </Component>
+              </div>
             </template>
-          </template>
-          <template v-else-if="fields">
+          </BAccordion>
+          <div v-else-if="fields" class="form-section p-3">
             <!-- @vue-ignore-next-line -->
             <Fields.reuse :fields-props="fields" />
-          </template>
+          </div>
         </slot>
 
         <slot name="server-error">
@@ -238,10 +247,6 @@ const Fields = createReusableTemplate<{
 </template>
 
 <style lang="scss" scoped>
-.card-title {
-  margin-bottom: 1em;
-  border-bottom: solid $border-width $gray-500;
-}
 .form-section:not(:last-child) {
   margin-bottom: 3rem;
 }

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -27,6 +27,8 @@ const props = withDefaults(
     noFooter?: boolean
     hr?: boolean
     sections?: ConfigSection<MV, FFD>[]
+    title?: string
+    icon?: string
   }>(),
   {
     id: 'ynh-form',
@@ -38,6 +40,8 @@ const props = withDefaults(
     noFooter: false,
     hr: false,
     sections: undefined,
+    title: undefined,
+    icon: undefined,
   },
 )
 
@@ -49,6 +53,7 @@ const emit = defineEmits<{
 
 const slots = defineSlots<
   {
+    header?: any
     top?: any
     disclaimer?: any
     'before-form'?: any
@@ -162,14 +167,19 @@ const Fields = createReusableTemplate<{
     </template>
   </Fields.define>
 
-  <YCard class="card-form" v-bind="$attrs">
-    <template #default>
+  <BCard class="card-form" no-body v-bind="$attrs">
+    <slot name="header">
+      <BCardHeader>
+        <h2><YIcon v-if="icon" :iname="icon" class="me-2" />{{ title }}</h2>
+      </BCardHeader>
+    </slot>
+
+    <BCardBody>
       <slot name="top" />
 
       <slot name="disclaimer" />
 
       <slot name="before-form" />
-
       <BForm
         :id="id"
         :inline="inline"
@@ -214,16 +224,17 @@ const Fields = createReusableTemplate<{
       </BForm>
 
       <slot name="after-form" />
-    </template>
+    </BCardBody>
 
-    <template v-if="!noFooter" #buttons>
-      <slot name="buttons">
-        <BButton type="submit" variant="success" :form="id">
-          {{ submitText ?? $t('save') }}
-        </BButton>
-      </slot>
-    </template>
-  </YCard>
+    <BCardFooter
+      v-if="!noFooter"
+      class="d-flex align-items-center justify-content-end"
+    >
+      <BButton type="submit" variant="success" :form="id">
+        {{ submitText ?? $t('save') }}
+      </BButton>
+    </BCardFooter>
+  </BCard>
 </template>
 
 <style lang="scss" scoped>

--- a/app/src/components/globals/CardForm.vue
+++ b/app/src/components/globals/CardForm.vue
@@ -194,7 +194,6 @@ const Fields = createReusableTemplate<{
                 v-if="section.name && section.visible"
                 header-tag="h3"
                 :visible="!section.collapsed"
-                class="form-section"
               >
                 <template #title>
                   <span class="fs-3">{{ section.name }}</span>

--- a/app/src/components/globals/YCard.vue
+++ b/app/src/components/globals/YCard.vue
@@ -5,7 +5,6 @@ import { ref } from 'vue'
 const props = withDefaults(
   defineProps<{
     id?: string
-    asTab?: boolean
     noBody?: boolean
     title?: string
     titleTag?: string
@@ -16,7 +15,6 @@ const props = withDefaults(
   }>(),
   {
     id: 'ynh-form',
-    asTab: false,
     noBody: false,
     title: undefined,
     titleTag: 'h2',
@@ -41,9 +39,9 @@ const visible = ref(!props.collapsed)
 <template>
   <BCard
     :no-body="collapsible ? true : noBody"
-    :class="{ 'border-0': asTab, collapsible: collapsible }"
+    :class="{ collapsible: collapsible }"
   >
-    <template v-if="!asTab" #header>
+    <template #header>
       <div class="w-100 d-flex align-items-center flex-wrap custom-header">
         <slot name="header">
           <Component :is="titleTag" class="custom-header-title">

--- a/app/src/components/globals/YListItem.vue
+++ b/app/src/components/globals/YListItem.vue
@@ -4,10 +4,12 @@ withDefaults(
     label: string
     sublabel?: string
     description?: string
+    imageSrc?: string
   }>(),
   {
     sublabel: undefined,
     description: undefined,
+    imageSrc: undefined,
   },
 )
 
@@ -20,22 +22,33 @@ const slots = defineSlots<{
   <BListGroupItem
     class="d-flex justify-content-between align-items-center pe-0"
   >
-    <div>
-      <h5>
-        <strong class="fw-bold">{{ label }}</strong>
-        <small v-if="sublabel" class="ms-1 text-secondary">
-          {{ sublabel }}
-        </small>
-      </h5>
-      <p v-if="description || slots.default" class="m-0">
-        <slot name="default">
-          {{ description }}
-        </slot>
-      </p>
+    <div class="d-flex">
+      <div v-if="imageSrc" class="me-3">
+        <img :src="imageSrc" />
+      </div>
+      <div>
+        <h5>
+          <strong class="fw-bold">{{ label }}</strong>
+          <small v-if="sublabel" class="ms-1 text-secondary">
+            {{ sublabel }}
+          </small>
+        </h5>
+        <p v-if="description || slots.default" class="m-0">
+          <slot name="default">
+            {{ description }}
+          </slot>
+        </p>
+      </div>
     </div>
 
     <YIcon iname="chevron-right" class="lg fs-sm ms-auto" />
   </BListGroupItem>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+img {
+  width: 2.5rem;
+  height: 100%;
+  object-fit: contain;
+}
+</style>

--- a/app/src/composables/configPanels.ts
+++ b/app/src/composables/configPanels.ts
@@ -282,6 +282,7 @@ function formatConfigPanel<NestedMV extends Obj, MV extends Obj<NestedMV>>(
       isActionSection: section.is_action_section,
       name: formatI18nField(section.name),
       visible: useExpression(section.visible, form),
+      collapsed: section.collapsed ?? false
     }
   })
 

--- a/app/src/composables/configPanels.ts
+++ b/app/src/composables/configPanels.ts
@@ -400,13 +400,19 @@ export function useConfigPanels<NestedMV extends Obj, MV extends Obj<NestedMV>>(
   config: ConfigPanels<NestedMV, MV>,
   tabId: MaybeRefOrGetter<keyof MV | undefined>,
   onPanelApply: OnPanelApply<MV>,
+  tabIdKey: string = 'tabId',
 ): ConfigPanelsProps<NestedMV, MV> {
   const router = useRouter()
   watch(
     () => toValue(tabId),
     (id) => {
       if (!id) {
-        router.replace({ params: { tabId: config.panels[0].id } })
+        router.replace({
+          params: {
+            ...router.currentRoute.value.params,
+            [tabIdKey]: config.panels[0].id,
+          },
+        })
       }
     },
     { immediate: true },

--- a/app/src/composables/useAutoModal.ts
+++ b/app/src/composables/useAutoModal.ts
@@ -21,7 +21,7 @@ export function useAutoModal() {
       ...(markdown
         ? { headerVariant: 'warning' }
         : {
-            hideHeader: true,
+            noHeader: true,
             bodyVariant: 'warning',
             bodyClass: ['fw-bold', 'rounded-top'],
           }),

--- a/app/src/router/routes.ts
+++ b/app/src/router/routes.ts
@@ -204,7 +204,7 @@ const routes: RouteRecordRaw[] = [
   },
   {
     name: 'app-info',
-    path: '/apps/:id/:tabId?',
+    path: '/apps/:id/:coreTabId?/:tabId?',
     component: () => import('@/views/app/AppInfo.vue'),
     props: true,
     meta: {

--- a/app/src/scss/_variables.scss
+++ b/app/src/scss/_variables.scss
@@ -128,6 +128,7 @@ $h4-font-size: $font-size-base * 1.25;
 $h5-font-size: $font-size-base * 1.1;
 
 $list-group-item-padding-y: $spacer * 0.75;
+$accordion-padding-x: $spacer;
 $modal-md: 600px;
 
 $form-feedback-invalid-color: shade-color($danger, 20%);

--- a/app/src/types/configPanels.ts
+++ b/app/src/types/configPanels.ts
@@ -57,6 +57,7 @@ export type ConfigSection<MV extends Obj, FFD extends FormFieldDict<MV>> = {
   isActionSection: boolean
   name?: string
   visible: boolean | ComputedRef<boolean>
+  collapsed: boolean
 }
 
 export type ConfigPanel<

--- a/app/src/types/core/api.ts
+++ b/app/src/types/core/api.ts
@@ -1,5 +1,5 @@
 import type { Obj, StateVariant, Translation } from '@/types/commons'
-import type { Permission } from '@/types/core/data'
+import type { AppPermInfos } from '@/types/core/data'
 import type { AnyOption } from '@/types/core/options'
 
 // APPS
@@ -117,7 +117,7 @@ export type AppInfo = {
   upgradable: string
   settings: { domain?: string; path?: string } & Obj
   setting_path: string
-  permissions: Obj<Permission & { sublabel: string }>
+  permissions: Obj<AppPermInfos & { sublabel: string }>
   manifest: AppMinManifest & {
     install: Obj<AnyOption>
     upstream: {

--- a/app/src/types/core/data.ts
+++ b/app/src/types/core/data.ts
@@ -15,16 +15,23 @@ export type UserDetails = {
   'mail-forward': string[]
   'mailbox-quota': { limit: string; use: string }
 }
-export type Permission = {
+export type SystemPermInfos = {
+  label: string
   allowed: string[]
   corresponding_users: string[]
-  auth_header: boolean
-  label: string
-  show_tile: boolean
   protected: boolean
+}
+export type AppPermInfos = SystemPermInfos & {
   url: string | null
   additional_urls: string[]
+  auth_header: boolean
+  show_tile: boolean
+  hide_from_public?: boolean
+  logo_hash?: string
+  description?: string
+  order?: number
 }
+export type Permission = SystemPermInfos | AppPermInfos
 export type Group = {
   members: string[]
   permissions: string[]

--- a/app/src/types/core/options.ts
+++ b/app/src/types/core/options.ts
@@ -27,6 +27,7 @@ export type CoreConfigSection = {
   name?: Translation
   options: AnyOption[]
   visible?: JSExpression
+  collapsed?: boolean
 }
 
 // OPTIONS

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -81,6 +81,7 @@ const [app, form, coreConfigData, appConfigData, configPanelErr] = await api
       version: app_.version,
       label,
       domain,
+      logo: app_.logo,
       url: domain && path ? `https://${domain}${path}` : null,
       allowedGroups: allowed.length ? allowed.join(', ') : t('nobody'),
       alternativeTo: joinOrNull(app_.from_catalog.potential_alternative_to),
@@ -291,7 +292,14 @@ async function uninstall() {
     <section class="border rounded p-3 mb-4">
       <div class="d-md-flex align-items-center mb-4">
         <h1 class="mb-3 mb-md-0">
-          <YIcon iname="cube" />
+          <template v-if="app.logo">
+            <img
+              :src="`https://10.118.36.150/yunohost/admin/applogos/${app.logo}.png`"
+            />
+          </template>
+          <template v-else>
+            <YIcon iname="cube" />
+          </template>
           {{ app.label }}
 
           <span class="text-secondary tiny">
@@ -396,6 +404,10 @@ async function uninstall() {
 </template>
 
 <style lang="scss" scoped>
+h1 img {
+  width: 2.5rem;
+}
+
 select {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -139,6 +139,11 @@ const coreConfig = useConfigPanels(
   formatConfigPanels(coreConfigData),
   () => props.coreTabId,
   ({ panelId, data, action }, onError) => {
+    if (action?.includes('uninstall')) {
+      // FIXME check if at some point bootstrap-vue allows to await for a defined modal to resolve
+      showModalUninstall.value = true
+      return
+    }
     api
       .put({
         uri: action
@@ -179,6 +184,7 @@ const fields = {
   },
 }
 const { v } = useForm(form, fields)
+const showModalUninstall = ref(false)
 const purge = ref(false)
 
 async function changeLabel(permName: string, i: number) {
@@ -229,9 +235,9 @@ async function dismissNotification(name: string) {
 
 async function uninstall() {
   const data = purge.value === true ? { purge: 1 } : {}
-  api.delete({ uri: 'apps/' + props.id, data }).then(() => {
-    router.push({ name: 'app-list' })
-  })
+  api
+    .put({ uri: `apps/${props.id}/actions/_core.operations.uninstall`, data })
+    .then(() => router.push({ name: 'app-list' }))
 }
 </script>
 
@@ -388,6 +394,7 @@ async function uninstall() {
 
     <BModal
       id="uninstall-modal"
+      v-model="showModalUninstall"
       centered
       :title="$t('confirm_uninstall', { name: id })"
       header-variant="warning"

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -37,7 +37,7 @@ const [search, filteredApps] = useSearch(apps, (s, app) =>
       <YListItem
         v-for="{ id, description, label } in filteredApps"
         :key="id"
-        :to="{ name: 'app-info', params: { id } }"
+        :to="{ name: 'app-info', params: { id, coreTabId: '_core' } }"
         :label="label"
         :sublabel="id"
         :description="description"

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -7,8 +7,11 @@ const apps = await api
   .get<AppList>({ uri: 'apps?full', initial: true })
   .then(({ apps }) => {
     return apps
-      .map(({ id, name, description, manifest }) => {
-        return { id, name: manifest.name, label: name, description }
+      .map(({ id, name, description, manifest, logo }) => {
+        const logoUrl = logo
+          ? `https://10.118.36.150/yunohost/admin/applogos/${logo}.png`
+          : undefined
+        return { id, name: manifest.name, label: name, description, logoUrl }
       })
       .sort((prev, app) => {
         return prev.label > app.label ? 1 : -1
@@ -35,12 +38,13 @@ const [search, filteredApps] = useSearch(apps, (s, app) =>
 
     <BListGroup>
       <YListItem
-        v-for="{ id, description, label } in filteredApps"
+        v-for="{ id, description, label, logoUrl } in filteredApps"
         :key="id"
         :to="{ name: 'app-info', params: { id, coreTabId: '_core' } }"
         :label="label"
         :sublabel="id"
         :description="description"
+        :image-src="logoUrl"
       />
     </BListGroup>
   </ViewSearch>

--- a/app/src/views/app/appData.ts
+++ b/app/src/views/app/appData.ts
@@ -1,11 +1,12 @@
 import { getKeys, joinOrNull } from '@/helpers/commons'
-import type { Obj } from '@/types/commons'
+import { formatI18nField } from '@/helpers/yunohostArguments'
+import type { Obj, Translation } from '@/types/commons'
 import type { AppLevel, AppManifest, AppState } from '@/types/core/api'
 
-export function formatAppNotifs(notifs: Obj<string> | null): string {
+export function formatAppNotifs(notifs: Obj<Translation> | null): string {
   if (!notifs) return ''
   return getKeys(notifs).reduce((acc, key) => {
-    return acc + '\n\n' + notifs[key]
+    return acc + '\n\n' + formatI18nField(notifs[key])
   }, '')
 }
 


### PR DESCRIPTION
Reflects change from https://github.com/YunoHost/yunohost/pull/1917

- use config panels instead of previous Operations tab in AppInfo