### PR TITLE
feat: add `debug` option to log sse msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ You can also install [Vue Devtools](https://addons.mozilla.org/fr/firefox/addon/
 
 On a YunoHost instance, the web admin files are located at `/usr/share/yunohost/admin`.
 
+### Debugging
+
+To log SSE messages, type `localStorage.setItem('debug', true)` in the console and reload the page. Type `localStorage.removeItem('debug')` to deactivate it.
+
 ### Translation maintenance
 
 #### Cleaning

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -35,7 +35,7 @@ export default [
           destructuredArrayIgnorePattern: '^_',
         },
       ],
-      'no-console': ['error', { allow: ['warn', 'error'] }],
+      'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
     },
   },
 ]

--- a/app/src/composables/useInfos.ts
+++ b/app/src/composables/useInfos.ts
@@ -38,6 +38,7 @@ function formatRoute({ params, args }: BreadcrumbRoutes) {
 export const useInfos = createGlobalState(() => {
   const router = useRouter()
 
+  const debug = useLocalStorage('debug', false)
   const host = ref(window.location.host)
   const installed = ref<boolean | undefined>()
   const connected = useLocalStorage('connected', false)
@@ -204,6 +205,7 @@ export const useInfos = createGlobalState(() => {
   }
 
   return {
+    debug,
     host,
     installed,
     connected,

--- a/app/src/composables/useSSE.ts
+++ b/app/src/composables/useSSE.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { STATUS_VARIANT, isOkStatus } from '@/helpers/yunohostArguments'
 import type { StateStatus } from '@/types/commons'
 import { useAutoToast } from './useAutoToast'
+import { useInfos } from './useInfos'
 import type { APIRequest, APIRequestAction, RequestCaller } from './useRequests'
 import { useRequests } from './useRequests'
 
@@ -81,6 +82,7 @@ export const useSSE = createGlobalState(() => {
   const reconnectionArgs = ref<ReconnectionArgs | null>(null)
   const reconnectTimeout = ref<number | undefined>()
   const { startRequest, endRequest, historyList } = useRequests()
+  const { debug } = useInfos()
   const nonOperationWithLock = ref<APIRequestAction | null>(null)
 
   const reconnecting = computed(() =>
@@ -108,9 +110,11 @@ export const useSSE = createGlobalState(() => {
         fn: (data: T) => void,
       ) {
         sse.addEventListener(name, (e) => {
+          const data = JSON.parse(e.data)
+          if (debug.value) console.debug(`SSE msg: ${name}`, data)
           // The server sends at least heartbeats every 10s, try to reconnect if we loose connection
           tryToReconnect({ initialDelay: 15000, origin: 'unknown' })
-          fn({ type: name, ...JSON.parse(e.data) })
+          fn({ type: name, ...data })
         })
       }
 


### PR DESCRIPTION
We lack observing SSE messages when debugging this feature. Add option thru localStorage to display messages in navigator console.

To activate it, type `localStorage.setItem('debug', true)` in the console and reload the page. 
Deactivate it with `localStorage.setItem('debug', false)` or `localStorage.removeItem('debug')`.