### PR TITLE
add logo placeholder so that text remains aligned in the grid

### DIFF
--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -8,7 +8,7 @@ const apps = await api
   .then(({ apps }) => {
     return apps
       .map(({ id, name, description, manifest, logo }) => {
-        const logoUrl = logo ? `./applogos/${logo}.png` : undefined
+        const logoUrl = logo ? `./applogos/${logo}.png` : 'data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
         return { id, name: manifest.name, label: name, description, logoUrl }
       })
       .sort((prev, app) => {


### PR DESCRIPTION
Hello,
This is a PR similar to what was recently merged in `yunohost-portal`: https://github.com/YunoHost/yunohost-portal/pull/27

1. Currently in `yunohost-admin`, text in tiles for installed apps list without logo is not aligned with the one of apps with logo.

    ![ynhadmin_applist1](https://github.com/user-attachments/assets/71cd1651-3394-4275-99d6-5475d8178c97)

2. Expected result after PR merge

    ![ynhadmin_applist2](https://github.com/user-attachments/assets/c2dc1422-c153-43cb-97ae-f41165a94566)



Note that although this is a simple PR, I did not test it in dev environment.  