### PR TITLE
Rework 'operations' part in app info page + improve the UI/UX for app and system packages upgrade

### DIFF
--- a/app/components.d.ts
+++ b/app/components.d.ts
@@ -75,6 +75,7 @@ declare module 'vue' {
     BToast: typeof import('bootstrap-vue-next/components/BToast')['BToast']
     BToastOrchestrator: typeof import('bootstrap-vue-next/components/BToast')['BToastOrchestrator']
     ButtonItem: typeof import('./src/components/globals/formItems/ButtonItem.vue')['default']
+    ButtonWithDetails: typeof import('./src/components/globals/ButtonWithDetails.vue')['default']
     CardCollapse: typeof import('./src/components/CardCollapse.vue')['default']
     CardDeckFeed: typeof import('./src/components/CardDeckFeed.vue')['default']
     CardForm: typeof import('./src/components/globals/CardForm.vue')['default']

--- a/app/src/components/globals/ButtonWithDetails.vue
+++ b/app/src/components/globals/ButtonWithDetails.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-
 withDefaults(
   defineProps<{
     label?: string
@@ -18,17 +17,12 @@ withDefaults(
     disabled: false,
   },
 )
-
 </script>
 
 <template>
-  <BRow
-    no-gutters
-    class="w-100"
-    align-v="center"
-  >
+  <BRow no-gutters class="w-100" align-v="center">
     <BCol>
-      <VueShowdown :markdown="details" :class="`text-${ variant }`" />
+      <VueShowdown :markdown="details" :class="`text-${variant}`" />
     </BCol>
     <BCol class="text-center" cols="12" md="4" lg="3">
       <BButton

--- a/app/src/components/globals/ButtonWithDetails.vue
+++ b/app/src/components/globals/ButtonWithDetails.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { Cols } from '@/types/commons'
+
+const props = withDefaults(
+  defineProps<{
+    label?: string
+    icon?: string
+    details?: string
+    onclick?: string
+    cols?: Cols
+    variant?: string
+    disabled?: boolean
+  }>(),
+  {
+    label: undefined,
+    icon: undefined,
+    details: undefined,
+    onclick: undefined,
+    variant: 'info',
+    disabled: false,
+  },
+)
+
+</script>
+
+<template>
+  <BRow
+    no-gutters
+    class="w-100"
+    align-v="center"
+  >
+    <BCol>
+      <VueShowdown :markdown="details" :class="`text-${ variant }`" />
+    </BCol>
+    <BCol class="text-center" cols="12" md="4" lg="3">
+      <BButton
+        :variant="variant"
+        class="mt-2 mt-md-0"
+        :class="disabled ? 'disabled' : ''"
+        @:click="onclick"
+      >
+        <YIcon :iname="icon" class="me-2" />
+        <span>{{ label }}</span>
+      </BButton>
+    </BCol>
+  </BRow>
+</template>

--- a/app/src/components/globals/ButtonWithDetails.vue
+++ b/app/src/components/globals/ButtonWithDetails.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 
-import type { Cols } from '@/types/commons'
-
-const props = withDefaults(
+withDefaults(
   defineProps<{
     label?: string
     icon?: string
     details?: string
     onclick?: string
-    cols?: Cols
     variant?: string
     disabled?: boolean
   }>(),

--- a/app/src/components/globals/formItems/FileItem.vue
+++ b/app/src/components/globals/formItems/FileItem.vue
@@ -77,7 +77,7 @@ const required = computed(() => 'required' in (props.validation ?? {}))
 <template>
   <BInputGroup class="w-100">
     <template v-if="modelValue.current" #prepend>
-      <div class="mb-2">
+      <div class="w-100 currentfile mb-2">
         {{ $t('form.current_file') }} <code>{{ modelValue.file!.name }}</code>
       </div>
     </template>
@@ -111,6 +111,10 @@ const required = computed(() => 'required' in (props.validation ?? {}))
 </template>
 
 <style lang="scss" scoped>
+.currentfile {
+  font-size: 0.8em;
+}
+
 // fix https://getbootstrap.com/docs/5.2/migration/#forms
 :deep(.custom-file-label) {
   color: $input-placeholder-color;

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -144,7 +144,7 @@
             "up_to_date": "This app is up to date!",
             "advertise_testing_version": "Looking for a new version from upstream? Maybe there's a 'testing' version you can help packagers with on the YunoHost package's git repository!",
             "upgrade": "Upgrade",
-            "force_upgrace": "Force-upgrade",
+            "force_upgrade": "Force-upgrade",
             "confirm": {
                 "apps": "Apps that will be upgraded",
                 "title": "Confirm app upgrades"
@@ -156,8 +156,8 @@
                     "title": "Post-upgrade notifications for '{name}'"
                 },
                 "pre": {
-                    "alert": "You should check those notifications before upgrading, there might be important stuff to know.",
-                    "title": "Be warned!"
+                    "alert": "You should read carefully the following notes before proceeding with the upgrade.",
+                    "title": "Important notes"
                 }
             },
             "stop": "Cancel next app upgrades"
@@ -192,6 +192,7 @@
     "configuration": "Configuration",
     "confirm_app_change_url": "Are you sure you want to change the app access URL?",
     "confirm_app_force_upgrade": "Are you sure you want to force-upgrade this app?",
+    "confirm_app_upgrade": "Are you sure you want to upgrade this app?",
     "confirm_change_maindomain": "Are you sure you want to change the main domain?",
     "confirm_delete": "Are you sure you want to delete {name}?",
     "confirm_firewall_close": "Are you sure you want to close port {port} for protocol {protocol}?",
@@ -384,6 +385,7 @@
         "installed_apps": "no installed apps | installed app | installed apps",
         "items": "no items | item | items",
         "logs": "no logs | log | logs",
+        "packages": "no packages | package | packages",
         "permissions": "no permissions | permission | permissions",
         "services": "no services | service | services",
         "users": "no users | user | users",
@@ -514,7 +516,7 @@
     "system": "System",
     "system_apps_nothing": "All apps are up to date!",
     "system_packages_nothing": "All system packages are up to date!",
-    "system_update": "System update",
+    "system_update": "Updates",
     "system_upgrade_all_applications_btn": "Upgrade all applications",
     "system_upgrade_all_packages_btn": "Upgrade all packages",
     "system_upgrade_btn": "Upgrade",
@@ -551,6 +553,12 @@
     "unauthorized": "Unauthorized",
     "unignore": "Unignore",
     "unknown": "Unknown",
+    "update": {
+        "refresh_cache": "Fetch available updates",
+        "stale_cache": "The system package cache (apt/dpkg) was updated {lastAptUpdate} hours ago, and the YunoHost apps catalog was updated {lastAppsCatalogUpdate} hours ago. Be sure to refresh them to get up-to-date information.",
+        "very_stale_cache": "The app catalog or system package cache (apt/dpkg) is outdated. Please start by refreshing the cache to get up-to-date information.",
+        "ok_cache": "The app catalog and system package cache (apt/dpkg) was updated less than one hour ago. But you can refresh them anytime to get up-to-date information."
+    },
     "upnp": "UPnP",
     "upnp_disabled": "UPnP is disabled.",
     "upnp_enabled": "UPnP is enabled.",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -55,6 +55,11 @@
     "api_waiting": "Waiting for the server's response…",
     "app": {
         "antifeatures": "This app has features you may not like:",
+        "change_url": {
+            "title": "Move the app to a different URL",
+            "change_url": "Change URL",
+            "not_supported": "Changing the URL where this app is installed is not currently supported for this app."
+        },
         "doc": {
             "admin": {
                 "title": "Admin doc"
@@ -131,9 +136,15 @@
         "open_this_app": "Open this app",
         "potential_alternative_to": "Potential alternative to:",
         "uninstall": {
+            "uninstall": "Uninstall",
+            "desc": "This will uninstall the app from your server.<br/>You will have the option to purge the data as well during the confirmation modal.",
             "purge_desc": "Remove the data directory associated with the app (this is usually data you uploaded yourself using the app)."
         },
         "upgrade": {
+            "up_to_date": "This app is up to date!",
+            "advertise_testing_version": "Looking for a new version from upstream? Maybe there's a 'testing' version you can help packagers with on the YunoHost package's git repository!",
+            "upgrade": "Upgrade",
+            "force_upgrace": "Force-upgrade",
             "confirm": {
                 "apps": "Apps that will be upgraded",
                 "title": "Confirm app upgrades"

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -90,7 +90,7 @@
     "system": "Système",
     "system_apps_nothing": "Toutes les applications sont à jour !",
     "system_packages_nothing": "Tous les packages système sont à jour !",
-    "system_update": "Mise à jour du système",
+    "system_update": "Mises à jour",
     "system_upgrade_btn": "Mettre à jour",
     "tcp": "TCP",
     "tools": "Outils",
@@ -160,7 +160,7 @@
     "only_highquality_apps": "Seulement les applications de bonne qualité",
     "only_decent_quality_apps": "Seulement les applications d'une qualité satisfaisante",
     "orphaned": "Non maintenue",
-    "orphaned_details": "Cette application n'a pas été maintenue depuis un certain temps. Elle peut encore fonctionner, mais ne recevra aucune mise à niveau jusqu'à ce que quelqu'un se porte volontaire pour s'en occuper. N'hésitez pas à contribuer à la faire revivre !",
+    "orphaned_details": "Cette application n'a pas été maintenue depuis un certain temps. Elle peut encore fonctionner, mais ne recevra aucune mise à jour jusqu'à ce que quelqu'un se porte volontaire pour s'en occuper. N'hésitez pas à contribuer à la faire revivre !",
     "from_to": "de {0} à {1}",
     "group_name": "Nom du groupe",
     "group": "Groupe",
@@ -451,20 +451,20 @@
         "upgrade": {
             "notifs": {
                 "pre": {
-                    "alert": "Vous devriez vérifier ces notifications avant de procéder à la mise à niveau, il pourrait y avoir des éléments d'information importants à connaître.",
-                    "title": "Avertissement !"
+                    "alert": "Vous devriez lire attentivement les notes suivantes avant de lancer les mises à jour.",
+                    "title": "Notes importantes"
                 },
                 "post": {
-                    "alert": "Il semble que la mise à jour se soit bien passée !\nVoici quelques informations que le responsable du paquet juge important de connaître à propos de cette mise à niveau.\nVous pouvez les retrouver dans la page d'information de l'application.",
-                    "title": "Notifications post-mise à niveau pour '{name}'"
+                    "alert": "Vous pourrez aussi retrouver ces messages dans la page d'information de l'application",
+                    "title": "Notes importantes suite à la mise à jour de {name}"
                 }
             },
             "confirm": {
-                "apps": "Applications qui seront mises à niveau",
-                "title": "Confirmez les mises à niveau des applications"
+                "apps": "Applications qui seront mises à jour",
+                "title": "Confirmez les mises à jour des applications"
             },
             "continue": "Passer à l'application suivante",
-            "stop": "Annuler les prochaines mises à niveau d'applications"
+            "stop": "Annuler les prochaines mises à jour d'applications"
         },
         "installed_version": "Version installée :",
         "open_this_app": "Ouvrir l'application",
@@ -475,8 +475,8 @@
             },
             "notifications": {
                 "understood": "Compris",
-                "post_upgrade": "Remarques suite à la mise à niveau",
-                "post_install": "Remarques suite à l'installation"
+                "post_upgrade": "Notes suite à la mise à jour",
+                "post_install": "Notes suite à l'installation"
             }
         },
         "info": {
@@ -505,8 +505,8 @@
                 "inprogress": "Cette application est encore expérimentale (pour être plus clair elle ne fonctionne pas super bien et n'est pas encore bien intégrée dans YunoHost). En conséquence, elle est susceptible de casser votre système ! Vous ne devriez probablement PAS l'installer si vous ne savez pas ce que vous faites.",
                 "install": "Cette application est déjà installée et ne peut être installée plus d'une fois.",
                 "lowquality": "Cette application peut fonctionner mais n'est pas bien intégrée dans YunoHost. Certaines fonctionnalités telles que l'authentification unique (SSO) et la sauvegarde/restauration peuvent ne pas être disponibles, ou ne pas respecter les bonnes pratiques.",
-                "ram": "Cette application nécessite {required} de RAM pour être installée/mise à niveau mais seul {current} est disponible actuellement. Même si cette application pouvait fonctionner, son processus d'installation nécessite une grande quantité de RAM. Votre serveur risque donc de geler (freezer) et de planter lamentablement.",
-                "version": "Cette application nécessite une version de YunoHost >= {required} et votre version installée est {current}, vous devriez envisager en premier lieu de mettre à niveau YunoHost."
+                "ram": "Cette application nécessite {required} de RAM pour être installée/mise à jour mais seul {current} est disponible actuellement. Même si cette application pouvait fonctionner, son processus d'installation nécessite une grande quantité de RAM. Votre serveur risque donc de geler (freezer) et de planter lamentablement.",
+                "version": "Cette application nécessite une version de YunoHost >= {required} et votre version installée est {current}, vous devriez envisager en premier lieu de mettre à jour YunoHost."
             },
             "try_demo": "Essayer la démonstration",
             "version": "Version actuelle : {version}"

--- a/app/src/scss/main.scss
+++ b/app/src/scss/main.scss
@@ -326,3 +326,11 @@ pre code {
   -ms-user-select: none;
   user-select: none;
 }
+
+// Ugly fix for markdown stuff
+// Markdown parsers always create <p> blocks for blocks of text .
+// but this result in various case when you want to have markdown inside a div,
+// and then the <p> introduces a margin-bottom: 1em; which is ugly zzzz
+p:last-child {
+  margin-bottom: 0;
+}

--- a/app/src/scss/main.scss
+++ b/app/src/scss/main.scss
@@ -331,6 +331,6 @@ pre code {
 // Markdown parsers always create <p> blocks for blocks of text .
 // but this result in various case when you want to have markdown inside a div,
 // and then the <p> introduces a margin-bottom: 1em; which is ugly zzzz
-p:last-child {
+.markdown p:last-child {
   margin-bottom: 0;
 }

--- a/app/src/types/core/api.ts
+++ b/app/src/types/core/api.ts
@@ -51,8 +51,8 @@ export type AppManifest = AppMinManifest & {
   requirements: Record<
     'required_yunohost_version' | 'arch' | 'install' | 'disk' | 'ram',
     {
-      pass: boolean
-      values: { current: string; required: string }
+      passed: boolean
+      error: string
     }
   >
   resources: Obj
@@ -105,6 +105,28 @@ export type Catalog = {
   }[]
 }
 
+export type AppUpgradeInfo = {
+  status:
+    | 'upgradable'
+    | 'up_to_date'
+    | 'url_required'
+    | 'bad_quality'
+    | 'fail_requirements'
+  message: string
+  url: string | null
+  current_version: string
+  new_version: string | null
+  new_revision: string | null
+  requirements: Obj | null
+  specific_channel: string | null
+  specific_channel_message: string | null
+  notifications: Obj<string>
+}
+
+export type AppUpgradeResult = {
+  notifications: Obj<Obj<Translation>>
+}
+
 export type AppInfo = {
   id: string
   description: string
@@ -115,8 +137,8 @@ export type AppInfo = {
   logo: string | null
   screenshot?: string
   upgradable: string
+  upgrade: AppUpgradeInfo
   settings: { domain?: string; path?: string } & Obj
-  setting_path: string
   permissions: Obj<AppPermInfos & { sublabel: string }>
   manifest: AppMinManifest & {
     install: Obj<AnyOption>
@@ -294,23 +316,18 @@ export type MigrationList = {
 }
 
 export type SystemUpdate = {
-  system: {
-    name: string
-    new_version: string
-    current_version: string
-  }[]
-  apps: {
-    name: string
-    id: string
-    new_version: string
-    current_version: string
-    notifications: {
-      PRE_UPGRADE: Obj<string> | null
-      POST_UPGRADE: Obj<string> | null
-    }
-  }[]
+  system: Obj<
+    {
+      name: string
+      new_version: string
+      current_version: string
+    }[]
+  >
+  apps: AppInfo[]
   important_yunohost_upgrade: boolean
   pending_migrations: MigrationInfo[]
+  last_apt_update: number
+  last_apps_catalog_update: number
 }
 
 // DOMAINS

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -36,91 +36,97 @@ const showModalUninstall = ref(false)
 const changeUrlErrors = ref('')
 const purge = ref(false)
 
-const [app, changeUrlForm, coreConfigData, appConfigData, configPanelErr] = await api
-  .fetchAll<[AppInfo, CoreConfigPanels]>([
-    { uri: `apps/${props.id}?full&with_pre_upgrade_notifications` },
-    { uri: `apps/${props.id}/config?full&core` },
-  ])
-  .then(async ([app_, coreConfigData]) => {
-    // Query config panels if app supports it
-    let appConfigData: CoreConfigPanels | undefined
-    let appConfigPanelErr: string | undefined
-    if (app_.supports_config_panel) {
-      await api
-        .get<CoreConfigPanels>(`apps/${props.id}/config?full`)
-        .then((data) => (appConfigData = data))
-        .catch((err: APIError) => (appConfigPanelErr = err.message))
-    }
-
-    const { domain, path } = app_.settings
-    const changeUrlForm = ref({
-      url: domain && path ? { domain, path: path.slice(1) } : undefined,
-    })
-    const permissions = []
-    for (const [name, perm] of toEntries(app_.permissions)) {
-      const isMain = name.endsWith('.main')
-      const permission = {
-        ...perm,
-        name,
-        label: isMain ? perm.label : perm.sublabel,
-        title: isMain ? t('permission_main') : humanPermissionName(name),
-        tileAvailable: !!perm.url && !perm.url.startsWith('re:'),
+const [app, changeUrlForm, coreConfigData, appConfigData, configPanelErr] =
+  await api
+    .fetchAll<
+      [AppInfo, CoreConfigPanels]
+    >([{ uri: `apps/${props.id}?full&with_pre_upgrade_notifications` }, { uri: `apps/${props.id}/config?full&core` }])
+    .then(async ([app_, coreConfigData]) => {
+      // Query config panels if app supports it
+      let appConfigData: CoreConfigPanels | undefined
+      let appConfigPanelErr: string | undefined
+      if (app_.supports_config_panel) {
+        await api
+          .get<CoreConfigPanels>(`apps/${props.id}/config?full`)
+          .then((data) => (appConfigData = data))
+          .catch((err: APIError) => (appConfigPanelErr = err.message))
       }
-      permissions.push(permission)
-    }
 
-    const { DESCRIPTION, ADMIN, ...doc } = app_.manifest.doc
-    const notifs = app_.manifest.notifications
-    // App may not have 'main' permission
-    const label = app_.label || app_.id
-    const app = {
-      id: props.id,
-      version: app_.version,
-      label,
-      domain,
-      logo: app_.logo,
-      url: domain && path ? `https://${domain}${path}` : null,
-      alternativeTo: joinOrNull(app_.from_catalog.potential_alternative_to),
-      description: formatI18nField(DESCRIPTION) || app_.description,
-      upgrade: app_.upgrade,
-      integration: formatAppIntegration(
-        app_.manifest.integration,
-        app_.manifest.packaging_format,
-      ),
-      // TODO: could return `remote` key of manifest to pass only manifest and id?
-      links: formatAppLinks({
-        ...app_.manifest,
-        // @ts-expect-error meh
-        remote: app_.from_catalog.git ?? { url: null },
-      }),
-      doc: {
-        notifications: {
-          postInstall: notifs.POST_INSTALL?.main
-            ? [['main', formatI18nField(notifs.POST_INSTALL.main)]]
-            : [],
-          postUpgrade: notifs.POST_UPGRADE
-            ? Object.entries(notifs.POST_UPGRADE).map(([key, content]) => {
-                return [key, formatI18nField(content)]
-              })
-            : [],
+      const { domain, path } = app_.settings
+      const changeUrlForm = ref({
+        url: domain && path ? { domain, path: path.slice(1) } : undefined,
+      })
+      const permissions = []
+      for (const [name, perm] of toEntries(app_.permissions)) {
+        const isMain = name.endsWith('.main')
+        const permission = {
+          ...perm,
+          name,
+          label: isMain ? perm.label : perm.sublabel,
+          title: isMain ? t('permission_main') : humanPermissionName(name),
+          tileAvailable: !!perm.url && !perm.url.startsWith('re:'),
+        }
+        permissions.push(permission)
+      }
+
+      const { DESCRIPTION, ADMIN, ...doc } = app_.manifest.doc
+      const notifs = app_.manifest.notifications
+      // App may not have 'main' permission
+      const label = app_.label || app_.id
+      const app = {
+        id: props.id,
+        version: app_.version,
+        label,
+        domain,
+        logo: app_.logo,
+        url: domain && path ? `https://${domain}${path}` : null,
+        alternativeTo: joinOrNull(app_.from_catalog.potential_alternative_to),
+        description: formatI18nField(DESCRIPTION) || app_.description,
+        upgrade: app_.upgrade,
+        integration: formatAppIntegration(
+          app_.manifest.integration,
+          app_.manifest.packaging_format,
+        ),
+        // TODO: could return `remote` key of manifest to pass only manifest and id?
+        links: formatAppLinks({
+          ...app_.manifest,
+          // @ts-expect-error meh
+          remote: app_.from_catalog.git ?? { url: null },
+        }),
+        doc: {
+          notifications: {
+            postInstall: notifs.POST_INSTALL?.main
+              ? [['main', formatI18nField(notifs.POST_INSTALL.main)]]
+              : [],
+            postUpgrade: notifs.POST_UPGRADE
+              ? Object.entries(notifs.POST_UPGRADE).map(([key, content]) => {
+                  return [key, formatI18nField(content)]
+                })
+              : [],
+          },
+          admin: [
+            ['admin', formatI18nField(ADMIN)],
+            ...Object.keys(doc)
+              .sort()
+              .map((key) => [
+                key.charAt(0) + key.slice(1).toLowerCase(),
+                formatI18nField(doc[key]),
+              ]),
+          ].filter((doc) => doc[1]),
         },
-        admin: [
-          ['admin', formatI18nField(ADMIN)],
-          ...Object.keys(doc)
-            .sort()
-            .map((key) => [
-              key.charAt(0) + key.slice(1).toLowerCase(),
-              formatI18nField(doc[key]),
-            ]),
-        ].filter((doc) => doc[1]),
-      },
-      isWebapp: app_.is_webapp,
-      supportsChangeUrl: app_.supports_change_url,
-      supportsPurge: app_.supports_purge,
-    }
+        isWebapp: app_.is_webapp,
+        supportsChangeUrl: app_.supports_change_url,
+        supportsPurge: app_.supports_purge,
+      }
 
-    return [app, changeUrlForm, coreConfigData, appConfigData, appConfigPanelErr] as const
-  })
+      return [
+        app,
+        changeUrlForm,
+        coreConfigData,
+        appConfigData,
+        appConfigPanelErr,
+      ] as const
+    })
 
 const coreConfig = useConfigPanels(
   formatConfigPanels(coreConfigData),
@@ -177,50 +183,59 @@ async function changeUrl() {
     })
     // Refetch because some content of this page relies on the url
     .then(() => api.refetch())
-    .catch(err => changeUrlErrors.value = err.message)
+    .catch((err) => (changeUrlErrors.value = err.message))
 }
 
 async function forceUpgrade() {
   const confirmed = await modalConfirm(t('confirm_app_force_upgrade'))
-  if (!confirmed) return;
-  await upgrade(true);
+  if (!confirmed) return
+  await upgrade(true)
 }
 
 async function regularUpgrade() {
-
   const confirmed = await modalConfirm(
-    app.upgrade.notifications ? "<strong><em>" + t('app.upgrade.notifs.pre.alert') + "</em></strong><hr/>" + formatAppNotifs(app.upgrade.notifications) : "",
+    app.upgrade.notifications
+      ? '<strong><em>' +
+          t('app.upgrade.notifs.pre.alert') +
+          '</em></strong><hr/>' +
+          formatAppNotifs(app.upgrade.notifications)
+      : '',
     {
       title: t('confirm_app_upgrade'),
     },
     { markdown: true },
   )
-  if (!confirmed) return;
-  await upgrade(false);
+  if (!confirmed) return
+  await upgrade(false)
 }
 
 async function upgrade(force) {
-  await api.put({uri: `apps/${app.id}/upgrade` + (force ? '?force' : '')})
-        .then((response) => {
-        const postMessage = formatAppNotifs(response.notifications.POST_UPGRADE)
-        if (postMessage) {
-          const message = "<small><em>" + t('app.upgrade.notifs.post.alert') + '</em></small>\n\n' + postMessage
-          modalConfirm(
-            message,
-            {
-              title: t('app.upgrade.notifs.post.title', {
-                name: app.label,
-              }),
-            },
-            { markdown: true, cancelable: false },
-          )
-        }
-        api.refetch()
-      })
+  await api
+    .put({ uri: `apps/${app.id}/upgrade` + (force ? '?force' : '') })
+    .then((response) => {
+      const postMessage = formatAppNotifs(response.notifications.POST_UPGRADE)
+      if (postMessage) {
+        const message =
+          '<small><em>' +
+          t('app.upgrade.notifs.post.alert') +
+          '</em></small>\n\n' +
+          postMessage
+        modalConfirm(
+          message,
+          {
+            title: t('app.upgrade.notifs.post.title', {
+              name: app.label,
+            }),
+          },
+          { markdown: true, cancelable: false },
+        )
+      }
+      api.refetch()
+    })
 }
 
 async function showModalUninstallButton() {
-  showModalUninstall.value = true;
+  showModalUninstall.value = true
 }
 
 async function uninstall() {
@@ -353,8 +368,12 @@ async function uninstall() {
         </BTab>
       </BTabs>
     </BCard>
-    <YCard v-else-if="app.doc.admin.length == 1" :title="$t('app.doc.admin.title')" icon="book">
-        <VueShowdown :markdown="app.doc.admin[0][1]" />
+    <YCard
+      v-else-if="app.doc.admin.length == 1"
+      :title="$t('app.doc.admin.title')"
+      icon="book"
+    >
+      <VueShowdown :markdown="app.doc.admin[0][1]" />
     </YCard>
 
     <!-- CORE CONFIG PANEL -->
@@ -367,26 +386,30 @@ async function uninstall() {
     />
 
     <YCard id="operations" :title="$t('operations')" icon="wrench">
-
       <!-- Upgrade -->
 
       <h5
-      :class="
-        app.upgrade.status == 'up_to_date' ? '' :
-        app.upgrade.status == 'upgradable' ? 'text-info' :
-        app.upgrade.status == 'url_required' ? 'text-muted' :
-        app.upgrade.status == 'bad_quality' ? 'text-warning' :
-        'text-info'
-      ">
+        :class="
+          app.upgrade.status == 'up_to_date'
+            ? ''
+            : app.upgrade.status == 'upgradable'
+              ? 'text-info'
+              : app.upgrade.status == 'url_required'
+                ? 'text-muted'
+                : app.upgrade.status == 'bad_quality'
+                  ? 'text-warning'
+                  : 'text-info'
+        "
+      >
         {{ $t('app.upgrade.upgrade') }}
       </h5>
 
       <YAlert
-         v-if="app.upgrade.specific_channel_message"
-         variant="warning"
-         class="py-2 m-2"
+        v-if="app.upgrade.specific_channel_message"
+        variant="warning"
+        class="py-2 m-2"
       >
-         <VueShowdown :markdown="app.upgrade.specific_channel_message" />
+        <VueShowdown :markdown="app.upgrade.specific_channel_message" />
       </YAlert>
 
       <div v-if="app.upgrade.status == 'up_to_date'" class="text-success">
@@ -397,7 +420,11 @@ async function uninstall() {
 
       <div v-if="app.upgrade.status == 'up_to_date'" class="pb-2">
         <small v-t="'app.upgrade.advertise_testing_version'"></small>
-        <BLink v-if="app.links.package" :href="app.links.package[1] + '/pulls'" target="_blank">
+        <BLink
+          v-if="app.links.package"
+          :href="app.links.package[1] + '/pulls'"
+          target="_blank"
+        >
           <YIcon iname="external-link" class="ms-2" />
         </BLink>
       </div>
@@ -416,15 +443,19 @@ async function uninstall() {
         icon="arrow-up"
         :details="app.upgrade.message"
         :variant="
-            app.upgrade.status == 'upgradable' ? 'success' :
-            app.upgrade.status == 'url_required' ? 'outline-secondary' :
-            app.upgrade.status == 'bad_quality' ? 'warning' :
-            'info'"
+          app.upgrade.status == 'upgradable'
+            ? 'success'
+            : app.upgrade.status == 'url_required'
+              ? 'outline-secondary'
+              : app.upgrade.status == 'bad_quality'
+                ? 'warning'
+                : 'info'
+        "
         :disabled="app.upgrade.status != 'upgradable'"
         :onclick="regularUpgrade"
       />
 
-      <hr/>
+      <hr />
 
       <!-- Change url -->
 
@@ -437,7 +468,6 @@ async function uninstall() {
       >
         <BCol>
           <BInputGroup v-if="app.supportsChangeUrl && changeUrlForm.url">
-
             <BInputGroupText>https://</BInputGroupText>
             <BFormSelect
               v-model="changeUrlForm.url.domain"
@@ -445,7 +475,6 @@ async function uninstall() {
             />
             <BInputGroupText>/</BInputGroupText>
             <BFormInput v-model="changeUrlForm.url.path" class="flex-grow-3" />
-
           </BInputGroup>
         </BCol>
         <BCol class="text-center" cols="12" md="4" lg="3">
@@ -462,12 +491,14 @@ async function uninstall() {
       </BRow>
 
       <div v-else-if="app.isWebapp">
-          {{ $t('app.change_url.not_supported') }}
+        {{ $t('app.change_url.not_supported') }}
       </div>
 
       <div v-if="changeUrlErrors" class="text-danger">
-          <VueShowdown :markdown="changeUrlErrors" :options="{ headerLevelStart: 4 }"
-      />
+        <VueShowdown
+          :markdown="changeUrlErrors"
+          :options="{ headerLevelStart: 4 }"
+        />
       </div>
 
       <hr v-if="app.isWebapp" />
@@ -483,7 +514,6 @@ async function uninstall() {
         variant="danger"
         :onclick="showModalUninstallButton"
       />
-
     </YCard>
 
     <AppIntegrationAndLinks :integration="app.integration" :links="app.links" />

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -10,6 +10,7 @@ import { formatConfigPanels, useConfigPanels } from '@/composables/configPanels'
 import { useDomains } from '@/composables/data'
 import { useAutoModal } from '@/composables/useAutoModal'
 import { isEmptyValue, joinOrNull, toEntries } from '@/helpers/commons'
+import type { Obj } from '@/types/commons'
 import { humanPermissionName } from '@/helpers/filters/human'
 import { formatI18nField } from '@/helpers/yunohostArguments'
 import type { AppInfo } from '@/types/core/api'
@@ -179,7 +180,6 @@ async function changeUrl() {
     .put({
       uri: `apps/${props.id}/changeurl`,
       data: { domain, path: '/' + path },
-      humanKey: { key: 'apps.change_url', name: app.label },
     })
     // Refetch because some content of this page relies on the url
     .then(() => api.refetch())
@@ -209,9 +209,9 @@ async function regularUpgrade() {
   await upgrade(false)
 }
 
-async function upgrade(force) {
+async function upgrade(force: boolean) {
   await api
-    .put({ uri: `apps/${app.id}/upgrade` + (force ? '?force' : '') })
+    .put<Obj>({ uri: `apps/${app.id}/upgrade` + (force ? '?force' : '') })
     .then((response) => {
       const postMessage = formatAppNotifs(response.notifications.POST_UPGRADE)
       if (postMessage) {
@@ -478,12 +478,7 @@ async function uninstall() {
           </BInputGroup>
         </BCol>
         <BCol class="text-center" cols="12" md="4" lg="3">
-          <BButton
-            variant="info"
-            class="mt-2 mt-md-0"
-            :class="disabled ? 'disabled' : ''"
-            @:click="changeUrl"
-          >
+          <BButton variant="info" class="mt-2 mt-md-0" @:click="changeUrl">
             <YIcon iname="truck" class="me-2" />
             <span>{{ $t('app.change_url.change_url') }}</span>
           </BButton>

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -351,14 +351,7 @@ async function uninstall() {
         </template>
       </p>
 
-      <p>
-        <YIcon iname="comments" /> {{ $t('app.info.problem') }}
-        <a :href="`https://forum.yunohost.org/tag/${id}`" target="_blank">
-          {{ $t('app.info.forum') }}
-        </a>
-      </p>
-
-      <VueShowdown :markdown="app.description" />
+      <VueShowdown :markdown="app.description" class="px-2" />
     </section>
 
     <!-- APP CONFIG PANEL -->
@@ -377,7 +370,7 @@ async function uninstall() {
     />
 
     <!-- ADMIN DOC -->
-    <BCard v-if="app.doc.admin.length" no-body>
+    <BCard v-if="app.doc.admin.length > 1" no-body>
       <BTabs card fill pills>
         <BTab v-for="[name, content] in app.doc.admin" :key="name">
           <template #title>
@@ -388,6 +381,11 @@ async function uninstall() {
         </BTab>
       </BTabs>
     </BCard>
+    <YCard v-else-if="app.doc.admin.length == 1" :title="$t('app.doc.admin.title')" icon="book">
+      <template v-for="[name, content] in app.doc.admin">
+        <VueShowdown :markdown="content" />
+      </template>
+    </YCard>
 
     <!-- CORE CONFIG PANEL -->
     <ConfigPanelsComponent

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -30,6 +30,11 @@ const props = defineProps<{
 const { t } = useI18n()
 const router = useRouter()
 const modalConfirm = useAutoModal()
+const { domainsAsChoices } = useDomains()
+
+const showModalUninstall = ref(false)
+const changeUrlErrors = ref('')
+const purge = ref(false)
 
 const [app, changeUrlForm, coreConfigData, appConfigData, configPanelErr] = await api
   .fetchAll<[AppInfo, CoreConfigPanels]>([
@@ -117,39 +122,10 @@ const [app, changeUrlForm, coreConfigData, appConfigData, configPanelErr] = awai
     return [app, changeUrlForm, coreConfigData, appConfigData, appConfigPanelErr] as const
   })
 
-const { domainsAsChoices } = useDomains()
-
 const coreConfig = useConfigPanels(
   formatConfigPanels(coreConfigData),
   () => props.coreTabId,
   async ({ panelId, data, action }, onError) => {
-    let confirmed: boolean | null | undefined = true
-    if (action?.includes('uninstall')) {
-      // FIXME check if at some point bootstrap-vue allows to await for a defined modal to resolve
-      showModalUninstall.value = true
-      return
-    } else if (action?.includes('force_upgrade')) {
-      confirmed = await modalConfirm(t('confirm_app_force_upgrade'))
-      if (!confirmed) return
-
-      if (app.preUpgradeMessage) {
-        const message =
-          t('app.upgrade.notifs.pre.alert') + '\n\n' + app.preUpgradeMessage
-        confirmed = await modalConfirm(
-          message,
-          {
-            title: t('app.upgrade.notifs.pre.title', {
-              name: app.label,
-            }),
-            okTitle: t('ok'),
-          },
-          { markdown: true },
-        )
-      }
-    } else if (action?.includes('change_url')) {
-      confirmed = await modalConfirm(t('confirm_app_change_url'))
-    }
-    if (!confirmed) return
     api
       .put({
         uri: action
@@ -180,10 +156,6 @@ const appConfig = appConfigData
       },
     )
   : undefined
-
-const showModalUninstall = ref(false)
-const changeUrlErrors = ref('')
-const purge = ref(false)
 
 async function dismissNotification(name: string) {
   api
@@ -382,9 +354,7 @@ async function uninstall() {
       </BTabs>
     </BCard>
     <YCard v-else-if="app.doc.admin.length == 1" :title="$t('app.doc.admin.title')" icon="book">
-      <template v-for="[name, content] in app.doc.admin">
-        <VueShowdown :markdown="content" />
-      </template>
+        <VueShowdown :markdown="app.doc.admin[0][1]" />
     </YCard>
 
     <!-- CORE CONFIG PANEL -->
@@ -441,7 +411,7 @@ async function uninstall() {
         :onclick="forceUpgrade"
       />
       <ButtonWithDetails
-        v-else=""
+        v-else
         :label="$t('app.upgrade.upgrade')"
         icon="arrow-up"
         :details="app.upgrade.message"
@@ -483,7 +453,7 @@ async function uninstall() {
             variant="info"
             class="mt-2 mt-md-0"
             :class="disabled ? 'disabled' : ''"
-            @:click="onclick"
+            @:click="changeUrl"
           >
             <YIcon iname="truck" class="me-2" />
             <span>{{ $t('app.change_url.change_url') }}</span>

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -338,7 +338,7 @@ async function uninstall() {
         </template>
       </p>
 
-      <VueShowdown :markdown="app.description" class="px-2" />
+      <VueShowdown :markdown="app.description" />
     </section>
 
     <!-- APP CONFIG PANEL -->

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -7,13 +7,12 @@ import api, { objectToParams } from '@/api'
 import { type APIError } from '@/api/errors'
 import ConfigPanelsComponent from '@/components/ConfigPanels.vue'
 import { formatConfigPanels, useConfigPanels } from '@/composables/configPanels'
+import { useDomains } from '@/composables/data'
 import { useAutoModal } from '@/composables/useAutoModal'
 import { isEmptyValue, joinOrNull, toEntries } from '@/helpers/commons'
 import { humanPermissionName } from '@/helpers/filters/human'
 import { formatI18nField } from '@/helpers/yunohostArguments'
-import type { Obj } from '@/types/commons'
 import type { AppInfo } from '@/types/core/api'
-import type { Permission } from '@/types/core/data'
 import type { CoreConfigPanels } from '@/types/core/options'
 import AppIntegrationAndLinks from './_AppIntegrationAndLinks.vue'
 import {
@@ -32,13 +31,10 @@ const { t } = useI18n()
 const router = useRouter()
 const modalConfirm = useAutoModal()
 
-const [app, coreConfigData, appConfigData, configPanelErr] = await api
-  .fetchAll<[AppInfo, CoreConfigPanels, Obj<Permission>]>([
-    { uri: `apps/${props.id}?full` },
+const [app, changeUrlForm, coreConfigData, appConfigData, configPanelErr] = await api
+  .fetchAll<[AppInfo, CoreConfigPanels]>([
+    { uri: `apps/${props.id}?full&with_pre_upgrade_notifications` },
     { uri: `apps/${props.id}/config?full&core` },
-    // FIXME permissions needed?
-    { uri: 'users/permissions?full', cachePath: 'permissions' },
-    { uri: 'domains', cachePath: 'domains' },
   ])
   .then(async ([app_, coreConfigData]) => {
     // Query config panels if app supports it
@@ -52,6 +48,9 @@ const [app, coreConfigData, appConfigData, configPanelErr] = await api
     }
 
     const { domain, path } = app_.settings
+    const changeUrlForm = ref({
+      url: domain && path ? { domain, path: path.slice(1) } : undefined,
+    })
     const permissions = []
     for (const [name, perm] of toEntries(app_.permissions)) {
       const isMain = name.endsWith('.main')
@@ -68,8 +67,7 @@ const [app, coreConfigData, appConfigData, configPanelErr] = await api
     const { DESCRIPTION, ADMIN, ...doc } = app_.manifest.doc
     const notifs = app_.manifest.notifications
     // App may not have 'main' permission
-    const label =
-      app_.permissions[props.id + '.main']?.label || app_.label || app_.id
+    const label = app_.label || app_.id
     const app = {
       id: props.id,
       version: app_.version,
@@ -79,6 +77,7 @@ const [app, coreConfigData, appConfigData, configPanelErr] = await api
       url: domain && path ? `https://${domain}${path}` : null,
       alternativeTo: joinOrNull(app_.from_catalog.potential_alternative_to),
       description: formatI18nField(DESCRIPTION) || app_.description,
+      upgrade: app_.upgrade,
       integration: formatAppIntegration(
         app_.manifest.integration,
         app_.manifest.packaging_format,
@@ -110,14 +109,15 @@ const [app, coreConfigData, appConfigData, configPanelErr] = await api
             ]),
         ].filter((doc) => doc[1]),
       },
+      isWebapp: app_.is_webapp,
+      supportsChangeUrl: app_.supports_change_url,
       supportsPurge: app_.supports_purge,
-      preUpgradeMessage: formatAppNotifs(
-        app_.manifest.notifications.PRE_UPGRADE,
-      ),
     }
 
-    return [app, coreConfigData, appConfigData, appConfigPanelErr] as const
+    return [app, changeUrlForm, coreConfigData, appConfigData, appConfigPanelErr] as const
   })
+
+const { domainsAsChoices } = useDomains()
 
 const coreConfig = useConfigPanels(
   formatConfigPanels(coreConfigData),
@@ -182,6 +182,7 @@ const appConfig = appConfigData
   : undefined
 
 const showModalUninstall = ref(false)
+const changeUrlErrors = ref('')
 const purge = ref(false)
 
 async function dismissNotification(name: string) {
@@ -189,6 +190,65 @@ async function dismissNotification(name: string) {
     .put({ uri: `apps/${props.id}/dismiss_notification/${name}` })
     // FIXME no need to refetch i guess, filter the reactive notifs?
     .then(() => api.refetch())
+}
+
+async function changeUrl() {
+  const confirmed = await modalConfirm(t('confirm_app_change_url'))
+  if (!confirmed) return
+
+  const { domain, path } = changeUrlForm.value.url!
+  api
+    .put({
+      uri: `apps/${props.id}/changeurl`,
+      data: { domain, path: '/' + path },
+      humanKey: { key: 'apps.change_url', name: app.label },
+    })
+    // Refetch because some content of this page relies on the url
+    .then(() => api.refetch())
+    .catch(err => changeUrlErrors.value = err.message)
+}
+
+async function forceUpgrade() {
+  const confirmed = await modalConfirm(t('confirm_app_force_upgrade'))
+  if (!confirmed) return;
+  await upgrade(true);
+}
+
+async function regularUpgrade() {
+
+  const confirmed = await modalConfirm(
+    app.upgrade.notifications ? "<strong><em>" + t('app.upgrade.notifs.pre.alert') + "</em></strong><hr/>" + formatAppNotifs(app.upgrade.notifications) : "",
+    {
+      title: t('confirm_app_upgrade'),
+    },
+    { markdown: true },
+  )
+  if (!confirmed) return;
+  await upgrade(false);
+}
+
+async function upgrade(force) {
+  await api.put({uri: `apps/${app.id}/upgrade` + (force ? '?force' : '')})
+        .then((response) => {
+        const postMessage = formatAppNotifs(response.notifications.POST_UPGRADE)
+        if (postMessage) {
+          const message = "<small><em>" + t('app.upgrade.notifs.post.alert') + '</em></small>\n\n' + postMessage
+          modalConfirm(
+            message,
+            {
+              title: t('app.upgrade.notifs.post.title', {
+                name: app.label,
+              }),
+            },
+            { markdown: true, cancelable: false },
+          )
+        }
+        api.refetch()
+      })
+}
+
+async function showModalUninstallButton() {
+  showModalUninstall.value = true;
 }
 
 async function uninstall() {
@@ -254,7 +314,7 @@ async function uninstall() {
     </YAlert>
 
     <section class="border rounded p-3 mb-4">
-      <div class="d-md-flex align-items-center mb-4">
+      <div class="d-md-flex align-items-center mb-2">
         <h1 class="mb-3 mb-md-0">
           <template v-if="app.logo">
             <img class="rounded" :src="`./applogos/${app.logo}.png`" />
@@ -262,6 +322,7 @@ async function uninstall() {
           <template v-else>
             <YIcon iname="cube" />
           </template>
+
           {{ app.label }}
 
           <span class="text-secondary tiny">
@@ -300,21 +361,12 @@ async function uninstall() {
       <VueShowdown :markdown="app.description" />
     </section>
 
+    <!-- APP CONFIG PANEL -->
     <YAlert v-if="configPanelErr" class="mb-4" variant="danger" icon="bug">
       <p>{{ $t('app.info.config_panel_error') }}</p>
       <p>{{ configPanelErr }}</p>
       <p>{{ $t('app.info.config_panel_error_please_report') }}</p>
     </YAlert>
-
-    <ConfigPanelsComponent
-      v-model="coreConfig.form.value"
-      :panel="coreConfig.panel.value"
-      :validations="coreConfig.v.value"
-      :routes="coreConfig.routes"
-      @apply="coreConfig.onPanelApply"
-    />
-
-    <!-- BASIC INFOS -->
     <ConfigPanelsComponent
       v-if="appConfig"
       v-model="appConfig.form.value"
@@ -324,6 +376,7 @@ async function uninstall() {
       @apply="appConfig.onPanelApply"
     />
 
+    <!-- ADMIN DOC -->
     <BCard v-if="app.doc.admin.length" no-body>
       <BTabs card fill pills>
         <BTab v-for="[name, content] in app.doc.admin" :key="name">
@@ -335,6 +388,135 @@ async function uninstall() {
         </BTab>
       </BTabs>
     </BCard>
+
+    <!-- CORE CONFIG PANEL -->
+    <ConfigPanelsComponent
+      v-model="coreConfig.form.value"
+      :panel="coreConfig.panel.value"
+      :validations="coreConfig.v.value"
+      :routes="coreConfig.routes"
+      @apply="coreConfig.onPanelApply"
+    />
+
+    <YCard id="operations" :title="$t('operations')" icon="wrench">
+
+      <!-- Upgrade -->
+
+      <h5
+      :class="
+        app.upgrade.status == 'up_to_date' ? '' :
+        app.upgrade.status == 'upgradable' ? 'text-info' :
+        app.upgrade.status == 'url_required' ? 'text-muted' :
+        app.upgrade.status == 'bad_quality' ? 'text-warning' :
+        'text-info'
+      ">
+        {{ $t('app.upgrade.upgrade') }}
+      </h5>
+
+      <YAlert
+         v-if="app.upgrade.specific_channel_message"
+         variant="warning"
+         class="py-2 m-2"
+      >
+         <VueShowdown :markdown="app.upgrade.specific_channel_message" />
+      </YAlert>
+
+      <div v-if="app.upgrade.status == 'up_to_date'" class="text-success">
+        <YIcon iname="check" class="pe-1" />
+        <span v-t="'app.upgrade.up_to_date'"></span>
+        <small class="ps-1 text-secondary">({{ app.version }})</small>
+      </div>
+
+      <div v-if="app.upgrade.status == 'up_to_date'" class="pb-2">
+        <small v-t="'app.upgrade.advertise_testing_version'"></small>
+        <BLink v-if="app.links.package" :href="app.links.package[1] + '/pulls'" target="_blank">
+          <YIcon iname="external-link" class="ms-2" />
+        </BLink>
+      </div>
+
+      <ButtonWithDetails
+        v-if="app.upgrade.status == 'up_to_date'"
+        :label="$t('app.upgrade.force_upgrade')"
+        icon="refresh"
+        :details="app.upgrade.message"
+        variant="outline-secondary"
+        :onclick="forceUpgrade"
+      />
+      <ButtonWithDetails
+        v-else=""
+        :label="$t('app.upgrade.upgrade')"
+        icon="arrow-up"
+        :details="app.upgrade.message"
+        :variant="
+            app.upgrade.status == 'upgradable' ? 'success' :
+            app.upgrade.status == 'url_required' ? 'outline-secondary' :
+            app.upgrade.status == 'bad_quality' ? 'warning' :
+            'info'"
+        :disabled="app.upgrade.status != 'upgradable'"
+        :onclick="regularUpgrade"
+      />
+
+      <hr/>
+
+      <!-- Change url -->
+
+      <h5 v-if="app.isWebapp">{{ $t('app.change_url.title') }}</h5>
+
+      <BRow
+        v-if="app.isWebapp && app.supportsChangeUrl && changeUrlForm.url"
+        no-gutters
+        class="button-with-details w-100"
+      >
+        <BCol>
+          <BInputGroup v-if="app.supportsChangeUrl && changeUrlForm.url">
+
+            <BInputGroupText>https://</BInputGroupText>
+            <BFormSelect
+              v-model="changeUrlForm.url.domain"
+              :options="domainsAsChoices"
+            />
+            <BInputGroupText>/</BInputGroupText>
+            <BFormInput v-model="changeUrlForm.url.path" class="flex-grow-3" />
+
+          </BInputGroup>
+        </BCol>
+        <BCol class="text-center" cols="12" md="4" lg="3">
+          <BButton
+            variant="info"
+            class="mt-2 mt-md-0"
+            :class="disabled ? 'disabled' : ''"
+            @:click="onclick"
+          >
+            <YIcon iname="truck" class="me-2" />
+            <span>{{ $t('app.change_url.change_url') }}</span>
+          </BButton>
+        </BCol>
+      </BRow>
+
+      <div v-else-if="app.isWebapp">
+          {{ $t('app.change_url.not_supported') }}
+      </div>
+
+      <div v-if="changeUrlErrors" class="text-danger">
+          <VueShowdown :markdown="changeUrlErrors" :options="{ headerLevelStart: 4 }"
+      />
+      </div>
+
+      <hr v-if="app.isWebapp" />
+
+      <!-- Uninstall -->
+
+      <h5 class="text-danger">{{ $t('app.uninstall.uninstall') }}</h5>
+
+      <ButtonWithDetails
+        :label="$t('app.uninstall.uninstall')"
+        icon="trash"
+        :details="$t('app.uninstall.desc')"
+        variant="danger"
+        :onclick="showModalUninstallButton"
+      />
+
+    </YCard>
 
     <AppIntegrationAndLinks :integration="app.integration" :links="app.links" />
 

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -50,10 +50,10 @@ const [app, form, fields] = await api
           return antifeature
         })
       : null
-    const hasDanger = quality.variant === 'danger' || !requirements.ram.pass
+    const hasDanger = quality.variant === 'danger' || !requirements.ram.passed
     const hasSupport = getKeys(requirements).every((key) => {
       // ram support is non-blocking requirement and handled on its own.
-      return key === 'ram' || requirements[key].pass
+      return key === 'ram' || requirements[key].passed
     })
 
     const app = {
@@ -237,21 +237,14 @@ function onDomainAdd(data: {
       >
         <h2>{{ $t('app.install.notifs.pre.critical') }}</h2>
 
-        <p v-if="!app.requirements.arch.pass">
-          {{ $t('app.install.problems.arch', app.requirements.arch.values) }}
+        <p v-if="!app.requirements.arch.passed">
+          {{ app.requirements.arch.error }}
         </p>
-        <p v-if="!app.requirements.install.pass">
-          {{
-            $t('app.install.problems.install', app.requirements.install.values)
-          }}
+        <p v-if="!app.requirements.install.passed">
+          {{ app.requirements.install.error }}
         </p>
-        <p v-if="!app.requirements.required_yunohost_version.pass">
-          {{
-            $t(
-              'app.install.problems.version',
-              app.requirements.required_yunohost_version.values,
-            )
-          }}
+        <p v-if="!app.requirements.required_yunohost_version.passed">
+          {{ app.requirements.required_yunohost_version.error }}
         </p>
       </YAlert>
 
@@ -272,8 +265,8 @@ function onDomainAdd(data: {
           <VueShowdown class="mb-3" :markdown="t('app.upvote', { id })" />
         </div>
 
-        <p v-if="!app.requirements.ram.pass">
-          {{ $t('app.install.problems.ram', app.requirements.ram.values) }}
+        <p v-if="!app.requirements.ram.passed">
+          {{ app.requirements.ram.error }}
         </p>
 
         <CheckboxItem

--- a/app/src/views/app/AppInstall.vue
+++ b/app/src/views/app/AppInstall.vue
@@ -161,7 +161,7 @@ function onDomainAdd(data: {
 <template>
   <div>
     <template v-if="app">
-      <section class="border rounded p-3 mb-4">
+      <section class="p-3 mb-4">
         <div class="d-md-flex align-items-center mb-4">
           <h1 class="mb-3 mb-md-0">
             {{ app.name }}

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -40,7 +40,7 @@ const [search, filteredApps] = useSearch(apps, (s, app) =>
       <YListItem
         v-for="{ id, description, label, logoUrl } in filteredApps"
         :key="id"
-        :to="{ name: 'app-info', params: { id, coreTabId: '_core' } }"
+        :to="{ name: 'app-info', params: { id } }"
         :label="label"
         :sublabel="id"
         :description="description"

--- a/app/src/views/app/_AppIntegrationAndLinks.vue
+++ b/app/src/views/app/_AppIntegrationAndLinks.vue
@@ -12,6 +12,7 @@ defineProps<{
     v-if="integration"
     id="app-integration"
     :title="$t('app.integration.title')"
+    icon="puzzle-piece"
     collapsible
     collapsed
     no-body

--- a/app/src/views/app/_AppIntegrationAndLinks.vue
+++ b/app/src/views/app/_AppIntegrationAndLinks.vue
@@ -82,7 +82,9 @@ defineProps<{
             i18n: app.links.userdoc
             i18n: app.links.website
           -->
-          <BLink :href="link" target="_blank">{{ $t('app.links.' + key) }}</BLink>
+          <BLink :href="link" target="_blank">{{
+            $t('app.links.' + key)
+          }}</BLink>
         </YListGroupItem>
       </template>
     </BListGroup>

--- a/app/src/views/app/_AppIntegrationAndLinks.vue
+++ b/app/src/views/app/_AppIntegrationAndLinks.vue
@@ -71,20 +71,18 @@ defineProps<{
     <BListGroup flush>
       <template v-for="([icon, link], key) in links" :key="key">
         <YListGroupItem v-if="link" no-status>
-          <YIcon :iname="icon" class="me-3" />
-          <BLink :href="link" target="_blank">
-            <!--
-              i18n: app.links.admindoc
-              i18n: app.links.code
-              i18n: app.links.forum
-              i18n: app.links.license
-              i18n: app.links.package
-              i18n: app.links.package_license
-              i18n: app.links.userdoc
-              i18n: app.links.website
-            -->
-            {{ $t('app.links.' + key) }}
-          </BLink>
+          <YIcon :iname="icon" class="me-2" />
+          <!--
+            i18n: app.links.admindoc
+            i18n: app.links.code
+            i18n: app.links.forum
+            i18n: app.links.license
+            i18n: app.links.package
+            i18n: app.links.package_license
+            i18n: app.links.userdoc
+            i18n: app.links.website
+          -->
+          <BLink :href="link" target="_blank">{{ $t('app.links.' + key) }}</BLink>
         </YListGroupItem>
       </template>
     </BListGroup>

--- a/app/src/views/app/appData.ts
+++ b/app/src/views/app/appData.ts
@@ -1,5 +1,4 @@
 import { getKeys, joinOrNull } from '@/helpers/commons'
-import { formatI18nField } from '@/helpers/yunohostArguments'
 import type { Obj, Translation } from '@/types/commons'
 import type { AppLevel, AppManifest, AppState } from '@/types/core/api'
 

--- a/app/src/views/app/appData.ts
+++ b/app/src/views/app/appData.ts
@@ -5,9 +5,7 @@ import type { AppLevel, AppManifest, AppState } from '@/types/core/api'
 
 export function formatAppNotifs(notifs: Obj<Translation> | null): string {
   if (!notifs) return ''
-  return getKeys(notifs).reduce((acc, key) => {
-    return acc + '\n\n' + formatI18nField(notifs[key])
-  }, '')
+  return getKeys(notifs).map(key => notifs[key]).join("\n\n<hr/>\n\n")
 }
 
 export function formatAppQuality(app: { state: AppState; level: AppLevel }) {

--- a/app/src/views/app/appData.ts
+++ b/app/src/views/app/appData.ts
@@ -4,7 +4,9 @@ import type { AppLevel, AppManifest, AppState } from '@/types/core/api'
 
 export function formatAppNotifs(notifs: Obj<Translation> | null): string {
   if (!notifs) return ''
-  return getKeys(notifs).map(key => notifs[key]).join("\n\n<hr/>\n\n")
+  return getKeys(notifs)
+    .map((key) => notifs[key])
+    .join('\n\n<hr/>\n\n')
 }
 
 export function formatAppQuality(app: { state: AppState; level: AppLevel }) {

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -105,19 +105,27 @@ async function performSystemUpgrade() {
 
     <!-- SYSTEM UPGRADE -->
     <YCard :title="$t('system')" icon="server" no-body>
-      <BListGroup v-if="system.length" flush>
+      <BListGroup v-if="Object.keys(system).length" flush free>
         <BListGroupItem
-          v-for="{ name, current_version, new_version } in system"
-          :key="name"
+          v-for="( packages, category ) in system"
+          :key="category"
+          header-tag="h3"
+          button-class="px-3 py-2"
         >
-          <h5 class="m-0">
-            {{ name }}
-            <small class="text-secondary">
-              ({{ $t('from_to', [current_version, new_version]) }})
-            </small>
-          </h5>
-        </BListGroupItem>
-      </BListGroup>
+          <template #title>
+            <span class="fw-bold">{{ category }}</span>
+            <small class="ms-1">({{ packages.length }} {{ $t('items.packages', packages.length) }})</small>
+          </template>
+          <ul class="mb-0">
+            <li v-for="{ name, current_version, new_version } in packages">
+              {{ name }}
+              <small class="text-secondary">
+                {{ $t('from_to', [current_version, new_version]) }}
+              </small>
+            </li>
+          </ul>
+        </BAccordionItem>
+      </BAccordion>
 
       <BCardBody v-else>
         <span class="text-success">
@@ -126,7 +134,7 @@ async function performSystemUpgrade() {
         </span>
       </BCardBody>
 
-      <template v-if="system.length" #buttons>
+      <template v-if="Object.keys(system).length" #buttons>
         <BButton
           v-t="'system_upgrade_all_packages_btn'"
           variant="success"

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -6,7 +6,7 @@ import { secondsToHours } from 'date-fns/secondsToHours'
 import api from '@/api'
 import { useAutoModal } from '@/composables/useAutoModal'
 import { useSSE } from '@/composables/useSSE'
-import type { SystemUpdate } from '@/types/core/api'
+import type { SystemUpdate, AppUpgradeResult } from '@/types/core/api'
 import { formatAppNotifs } from '../app/appData'
 
 const { t } = useI18n()
@@ -63,7 +63,7 @@ async function confirmAppsUpgrade(id?: string) {
     id: app.id,
     name: app.name,
     currentVersion: app.upgrade.current_version,
-    newVersion: app.upgrade.new_version,
+    newVersion: app.upgrade.new_version || '',
     notif: formatAppNotifs(app.upgrade.notifications),
   }))
   preUpgrade.value = { apps: apps_, hasNotifs: apps_.some((app) => app.notif) }
@@ -75,7 +75,7 @@ async function performAppsUpgrade(ids: string[]) {
 
   for (const app of apps_) {
     const continue_ = await api
-      .put<Pick<SystemUpdate['apps'][number], 'notifications'>>({
+      .put<AppUpgradeResult>({
         uri: `apps/${app.id}/upgrade`,
       })
       .then((response) => {
@@ -118,13 +118,13 @@ async function performSystemUpgrade() {
   if (!confirmed) return
 
   api.put({ uri: 'upgrade/system' }).then(() => {
-    if (system.value.some(({ name }) => name.includes('yunohost'))) {
+    if ('yunohost' in system) {
       tryToReconnect({
         origin: 'upgrade_system',
         initialDelay: 2000,
       })
     }
-    system.value = []
+    api.refetch()
   })
 }
 </script>
@@ -156,7 +156,7 @@ async function performSystemUpgrade() {
             { lastAptUpdate, lastAppsCatalogUpdate },
           )
         "
-        :variant="info"
+        variant="info"
         :onclick="refreshUpdateCache"
       />
     </YAlert>
@@ -333,7 +333,7 @@ async function performSystemUpgrade() {
           {{ $t('app.upgrade.notifs.pre.alert') }}
         </YAlert>
 
-        <BAccordion :title="name" visible free>
+        <BAccordion visible free>
           <BAccordionItem
             v-for="{
               id,

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -13,25 +13,52 @@ const { t } = useI18n()
 const { tryToReconnect } = useSSE()
 const modalConfirm = useAutoModal()
 
-const { apps, system, importantYunohostUpgrade, pendingMigrations, lastAptUpdate, lastAppsCatalogUpdate } = await api
+const {
+  apps,
+  system,
+  importantYunohostUpgrade,
+  pendingMigrations,
+  lastAptUpdate,
+  lastAppsCatalogUpdate,
+} = await api
   .get<SystemUpdate>({ uri: 'update' })
-  .then(({ apps, system, important_yunohost_upgrade, pending_migrations, last_apt_update, last_apps_catalog_update }) => {
-    return {
-      apps: ref(apps.filter(app => app.upgrade.status != 'up_to_date')),
-      system: ref(system),
-      importantYunohostUpgrade: important_yunohost_upgrade,
-      pendingMigrations: !!pending_migrations.length,
-      lastAptUpdate: secondsToHours(last_apt_update),
-      lastAppsCatalogUpdate: secondsToHours(last_apps_catalog_update),
-    }
-  })
+  .then(
+    ({
+      apps,
+      system,
+      important_yunohost_upgrade,
+      pending_migrations,
+      last_apt_update,
+      last_apps_catalog_update,
+    }) => {
+      return {
+        apps: ref(apps.filter((app) => app.upgrade.status != 'up_to_date')),
+        system: ref(system),
+        importantYunohostUpgrade: important_yunohost_upgrade,
+        pendingMigrations: !!pending_migrations.length,
+        lastAptUpdate: secondsToHours(last_apt_update),
+        lastAppsCatalogUpdate: secondsToHours(last_apps_catalog_update),
+      }
+    },
+  )
 const preUpgrade = ref<
-  | { apps: { id: string; name: string; currentVersion: string, newVersion: string, notif: string, }[]; hasNotifs: boolean }
+  | {
+      apps: {
+        id: string
+        name: string
+        currentVersion: string
+        newVersion: string
+        notif: string
+      }[]
+      hasNotifs: boolean
+    }
   | undefined
 >()
 
 async function confirmAppsUpgrade(id?: string) {
-  const appList = id ? [apps.value.find((app) => app.id === id)!] : apps.value.filter(app => app.upgrade.status == 'upgradable');
+  const appList = id
+    ? [apps.value.find((app) => app.id === id)!]
+    : apps.value.filter((app) => app.upgrade.status == 'upgradable')
   const apps_ = appList.map((app) => ({
     id: app.id,
     name: app.name,
@@ -57,7 +84,11 @@ async function performAppsUpgrade(ids: string[]) {
         apps.value = apps.value.filter((a) => app.id !== a.id)
 
         if (postMessage) {
-          const message = "<small><em>" + t('app.upgrade.notifs.post.alert') + '</em></small>\n\n' + postMessage
+          const message =
+            '<small><em>' +
+            t('app.upgrade.notifs.post.alert') +
+            '</em></small>\n\n' +
+            postMessage
           return modalConfirm(
             message,
             {
@@ -79,8 +110,7 @@ async function performAppsUpgrade(ids: string[]) {
 }
 
 async function refreshUpdateCache() {
-  api.put<SystemUpdate>({ uri: 'update/all' })
-  .then(() => api.refetch())
+  api.put<SystemUpdate>({ uri: 'update/all' }).then(() => api.refetch())
 }
 
 async function performSystemUpgrade() {
@@ -116,32 +146,47 @@ async function performSystemUpgrade() {
       <ButtonWithDetails
         :label="t('update.refresh_cache')"
         icon="refresh"
-        :details="t(
-          lastAptUpdate > 12 || lastAppsCatalogUpdate > 12 ? 'update.very_stale_cache' :
-          lastAptUpdate > 1 || lastAppsCatalogUpdate > 1 ? 'update.stale_cache' : 
-          'update.ok_cache',
-          {lastAptUpdate, lastAppsCatalogUpdate}
-          )"
+        :details="
+          t(
+            lastAptUpdate > 12 || lastAppsCatalogUpdate > 12
+              ? 'update.very_stale_cache'
+              : lastAptUpdate > 1 || lastAppsCatalogUpdate > 1
+                ? 'update.stale_cache'
+                : 'update.ok_cache',
+            { lastAptUpdate, lastAppsCatalogUpdate },
+          )
+        "
         :variant="info"
         :onclick="refreshUpdateCache"
       />
     </YAlert>
 
     <!-- SYSTEM UPGRADE -->
-    <YCard v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12" :title="$t('system')" icon="server" no-body>
+    <YCard
+      v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12"
+      :title="$t('system')"
+      icon="server"
+      no-body
+    >
       <BAccordion v-if="Object.keys(system).length" flush free>
         <BAccordionItem
-          v-for="( packages, category ) in system"
+          v-for="(packages, category) in system"
           :key="category"
           header-tag="h3"
           button-class="px-3 py-2"
         >
           <template #title>
             <span class="fw-bold">{{ category }}</span>
-            <small class="ms-1">({{ packages.length }} {{ $t('items.packages', packages.length) }})</small>
+            <small class="ms-1"
+              >({{ packages.length }}
+              {{ $t('items.packages', packages.length) }})</small
+            >
           </template>
           <ul class="mb-0">
-            <li v-for="{ name, current_version, new_version } in packages" :key="name">
+            <li
+              v-for="{ name, current_version, new_version } in packages"
+              :key="name"
+            >
               {{ name }}
               <small class="text-secondary">
                 {{ $t('from_to', [current_version, new_version]) }}
@@ -168,7 +213,12 @@ async function performSystemUpgrade() {
     </YCard>
 
     <!-- APPS UPGRADE -->
-    <YCard v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12" :title="$t('applications')" icon="cubes" no-body>
+    <YCard
+      v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12"
+      :title="$t('applications')"
+      icon="cubes"
+      no-body
+    >
       <BListGroup v-if="apps.length" flush free>
         <BListGroupItem
           v-for="{ name, id, upgrade } in apps"
@@ -176,36 +226,56 @@ async function performSystemUpgrade() {
           class="d-flex justify-content-between align-items-center ps-3 pe-1"
         >
           <BRow align-v="center" class="w-100">
-          <BCol class="text-center text-md-start">
-            <h5 class="mb-1">
-              <span class="fw-bold">{{ name }}</span>
-              <small>
-                ({{ id }})
-                <span v-if="upgrade.new_version" class="text-secondary d-block d-sm-inline">
-                {{ $t('from_to', [upgrade.current_version, upgrade.new_version]) }}
-                </span>
-              </small>
-            </h5>
+            <BCol class="text-center text-md-start">
+              <h5 class="mb-1">
+                <span class="fw-bold">{{ name }}</span>
+                <small>
+                  ({{ id }})
+                  <span
+                    v-if="upgrade.new_version"
+                    class="text-secondary d-block d-sm-inline"
+                  >
+                    {{
+                      $t('from_to', [
+                        upgrade.current_version,
+                        upgrade.new_version,
+                      ])
+                    }}
+                  </span>
+                </small>
+              </h5>
 
-            <div v-if="upgrade.specific_channel" class="text-start text-warning alert alert-warning py-1 my-1">
-              <VueShowdown :markdown="upgrade.specific_channel_message" />
-            </div>
+              <div
+                v-if="upgrade.specific_channel"
+                class="text-start text-warning alert alert-warning py-1 my-1"
+              >
+                <VueShowdown :markdown="upgrade.specific_channel_message" />
+              </div>
 
-            <div v-if="upgrade.status != 'upgradable'" class="text-start mt-1 mb-0">
-              <VueShowdown :markdown="upgrade.message" />
-            </div>
-          </BCol>
+              <div
+                v-if="upgrade.status != 'upgradable'"
+                class="text-start mt-1 mb-0"
+              >
+                <VueShowdown :markdown="upgrade.message" />
+              </div>
+            </BCol>
 
-          <BCol class="text-center text-md-end pe-0" cols="12" md="2">
-          <BButton
-            v-if="upgrade.status != 'url_required'"
-            v-t="'system_upgrade_btn'"
-            :variant="upgrade.status != 'upgradable' ? 'outline-secondary' : upgrade.specific_channel ? 'warning' : 'success'"
-            :class="upgrade.status != 'upgradable' ? 'disabled' : ''"
-            size="sm"
-            @click="confirmAppsUpgrade(id)"
-          />
-          </BCol>
+            <BCol class="text-center text-md-end pe-0" cols="12" md="2">
+              <BButton
+                v-if="upgrade.status != 'url_required'"
+                v-t="'system_upgrade_btn'"
+                :variant="
+                  upgrade.status != 'upgradable'
+                    ? 'outline-secondary'
+                    : upgrade.specific_channel
+                      ? 'warning'
+                      : 'success'
+                "
+                :class="upgrade.status != 'upgradable' ? 'disabled' : ''"
+                size="sm"
+                @click="confirmAppsUpgrade(id)"
+              />
+            </BCol>
           </BRow>
         </BListGroupItem>
       </BListGroup>
@@ -242,7 +312,10 @@ async function performSystemUpgrade() {
         {{ $t('app.upgrade.confirm.apps') }}
       </h3>
       <ul>
-        <li v-for="{ name, id, currentVersion, newVersion } in preUpgrade.apps" :key="id">
+        <li
+          v-for="{ name, id, currentVersion, newVersion } in preUpgrade.apps"
+          :key="id"
+        >
           <span class="fw-bold pe-1">{{ name }}</span>
           <small class="text-muted">
             ({{ id }})
@@ -260,13 +333,15 @@ async function performSystemUpgrade() {
           {{ $t('app.upgrade.notifs.pre.alert') }}
         </YAlert>
 
-        <BAccordion
-          :title="name"
-          visible
-          free
-        >
+        <BAccordion :title="name" visible free>
           <BAccordionItem
-            v-for="{ id, name, currentVersion, newVersion, notif } in preUpgrade.apps"
+            v-for="{
+              id,
+              name,
+              currentVersion,
+              newVersion,
+              notif,
+            } in preUpgrade.apps"
             :key="`${id}-notifs`"
             header-tag="h3"
             button-class="px-3 py-2"
@@ -279,10 +354,7 @@ async function performSystemUpgrade() {
                 {{ $t('from_to', [currentVersion, newVersion]) }}
               </small>
             </template>
-            <VueShowdown
-                :markdown="notif"
-                :options="{ headerLevelStart: 6 }"
-              />
+            <VueShowdown :markdown="notif" :options="{ headerLevelStart: 6 }" />
           </BAccordionItem>
         </BAccordion>
       </div>

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -17,7 +17,7 @@ const { apps, system, importantYunohostUpgrade, pendingMigrations } = await api
   .put<SystemUpdate>({ uri: 'update/all' })
   .then(({ apps, system, important_yunohost_upgrade, pending_migrations }) => {
     return {
-      apps: ref(apps),
+      apps: ref(apps.filter(app => app.upgrade.status != 'up_to_date')),
       system: ref(system),
       importantYunohostUpgrade: important_yunohost_upgrade,
       pendingMigrations: !!pending_migrations.length,
@@ -29,11 +29,11 @@ const preUpgrade = ref<
 >()
 
 async function confirmAppsUpgrade(id?: string) {
-  const appList = id ? [apps.value.find((app) => app.id === id)!] : apps.value
+  const appList = id ? [apps.value.find((app) => app.id === id)!] : apps.value.filter(app => app.upgrade.status == 'upgradable');
   const apps_ = appList.map((app) => ({
     id: app.id,
     name: app.name,
-    notif: formatAppNotifs(app.notifications.PRE_UPGRADE),
+    notif: formatAppNotifs(app.upgrade.notifications.PRE_UPGRADE),
   }))
   preUpgrade.value = { apps: apps_, hasNotifs: apps_.some((app) => app.notif) }
 }
@@ -139,24 +139,42 @@ async function performSystemUpgrade() {
     <YCard :title="$t('applications')" icon="cubes" no-body>
       <BListGroup v-if="apps.length" flush>
         <BListGroupItem
-          v-for="{ name, id, current_version, new_version } in apps"
+          v-for="{ name, id, upgrade } in apps"
           :key="id"
-          class="d-flex justify-content-between align-items-center"
+          class="d-flex justify-content-between align-items-center ps-3 pe-1"
         >
-          <h5 class="m-0">
-            {{ name }}
-            <small>
-              ({{ id }})
-              {{ $t('from_to', [current_version, new_version]) }}
-            </small>
-          </h5>
+          <BRow align-v="center" class="w-100">
+          <BCol class="text-center text-md-start">
+            <h5 class="mb-1">
+              <span class="fw-bold">{{ name }}</span>
+              <small>
+                ({{ id }})
+                <span class="text-secondary d-block d-sm-inline" v-if="upgrade.new_version">
+                {{ $t('from_to', [upgrade.current_version, upgrade.new_version]) }}
+                </span>
+              </small>
+            </h5>
 
+            <div v-if="upgrade.specific_channel" class="text-start text-warning alert alert-warning py-1 my-1">
+              <VueShowdown :markdown="upgrade.specific_channel_message" />
+            </div>
+
+            <div v-if="upgrade.status != 'upgradable'" class="text-start mt-1 mb-0">
+              <VueShowdown :markdown="upgrade.message" />
+            </div>
+          </BCol>
+
+          <BCol class="text-center text-md-end pe-0" cols="12" md="2">
           <BButton
+            v-if="upgrade.status != 'url_required'"
             v-t="'system_upgrade_btn'"
-            variant="success"
+            :variant="upgrade.status != 'upgradable' ? 'outline-secondary' : upgrade.specific_channel ? 'warning' : 'success'"
+            :class="upgrade.status != 'upgradable' ? 'disabled' : ''"
             size="sm"
             @click="confirmAppsUpgrade(id)"
           />
+          </BCol>
+          </BRow>
         </BListGroupItem>
       </BListGroup>
 

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -4,7 +4,6 @@ import { useI18n } from 'vue-i18n'
 import { secondsToHours } from 'date-fns/secondsToHours'
 
 import api from '@/api'
-import CardCollapse from '@/components/CardCollapse.vue'
 import { useAutoModal } from '@/composables/useAutoModal'
 import { useSSE } from '@/composables/useSSE'
 import type { SystemUpdate } from '@/types/core/api'
@@ -142,7 +141,7 @@ async function performSystemUpgrade() {
             <small class="ms-1">({{ packages.length }} {{ $t('items.packages', packages.length) }})</small>
           </template>
           <ul class="mb-0">
-            <li v-for="{ name, current_version, new_version } in packages">
+            <li v-for="{ name, current_version, new_version } in packages" :key="name">
               {{ name }}
               <small class="text-secondary">
                 {{ $t('from_to', [current_version, new_version]) }}
@@ -182,7 +181,7 @@ async function performSystemUpgrade() {
               <span class="fw-bold">{{ name }}</span>
               <small>
                 ({{ id }})
-                <span class="text-secondary d-block d-sm-inline" v-if="upgrade.new_version">
+                <span v-if="upgrade.new_version" class="text-secondary d-block d-sm-inline">
                 {{ $t('from_to', [upgrade.current_version, upgrade.new_version]) }}
                 </span>
               </small>

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -27,7 +27,7 @@ const { apps, system, importantYunohostUpgrade, pendingMigrations, lastAptUpdate
     }
   })
 const preUpgrade = ref<
-  | { apps: { id: string; name: string; notif: string }[]; hasNotifs: boolean }
+  | { apps: { id: string; name: string; currentVersion: string, newVersion: string, notif: string, }[]; hasNotifs: boolean }
   | undefined
 >()
 
@@ -36,7 +36,9 @@ async function confirmAppsUpgrade(id?: string) {
   const apps_ = appList.map((app) => ({
     id: app.id,
     name: app.name,
-    notif: formatAppNotifs(app.upgrade.notifications.PRE_UPGRADE),
+    currentVersion: app.upgrade.current_version,
+    newVersion: app.upgrade.new_version,
+    notif: formatAppNotifs(app.upgrade.notifications),
   }))
   preUpgrade.value = { apps: apps_, hasNotifs: apps_.some((app) => app.notif) }
 }
@@ -56,8 +58,7 @@ async function performAppsUpgrade(ids: string[]) {
         apps.value = apps.value.filter((a) => app.id !== a.id)
 
         if (postMessage) {
-          const message =
-            t('app.upgrade.notifs.post.alert') + '\n\n' + postMessage
+          const message = "<small><em>" + t('app.upgrade.notifs.post.alert') + '</em></small>\n\n' + postMessage
           return modalConfirm(
             message,
             {
@@ -169,7 +170,7 @@ async function performSystemUpgrade() {
 
     <!-- APPS UPGRADE -->
     <YCard v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12" :title="$t('applications')" icon="cubes" no-body>
-      <BListGroup v-if="apps.length" flush>
+      <BListGroup v-if="apps.length" flush free>
         <BListGroupItem
           v-for="{ name, id, upgrade } in apps"
           :key="id"
@@ -242,8 +243,12 @@ async function performSystemUpgrade() {
         {{ $t('app.upgrade.confirm.apps') }}
       </h3>
       <ul>
-        <li v-for="{ name, id } in preUpgrade.apps" :key="id">
-          {{ name }} ({{ id }})
+        <li v-for="{ name, id, currentVersion, newVersion } in preUpgrade.apps" :key="id">
+          <span class="fw-bold pe-1">{{ name }}</span>
+          <small class="text-muted">
+            ({{ id }})
+            {{ $t('from_to', [currentVersion, newVersion]) }}
+          </small>
         </li>
       </ul>
 
@@ -256,42 +261,32 @@ async function performSystemUpgrade() {
           {{ $t('app.upgrade.notifs.pre.alert') }}
         </YAlert>
 
-        <div class="card-collapse-wrapper">
-          <CardCollapse
-            v-for="{ id, name, notif } in preUpgrade.apps"
-            :id="`${id}-notifs`"
+        <BAccordion
+          :title="name"
+          visible
+          free
+        >
+          <BAccordionItem
+            v-for="{ id, name, currentVersion, newVersion, notif } in preUpgrade.apps"
             :key="`${id}-notifs`"
-            :title="name"
+            header-tag="h3"
+            button-class="px-3 py-2"
             visible
-            flush
           >
-            <BCardBody>
-              <VueShowdown
+            <template #title>
+              <span class="fw-bold pe-1">{{ name }}</span>
+              <small class="text-muted">
+                ({{ id }})
+                {{ $t('from_to', [currentVersion, newVersion]) }}
+              </small>
+            </template>
+            <VueShowdown
                 :markdown="notif"
                 :options="{ headerLevelStart: 6 }"
               />
-            </BCardBody>
-          </CardCollapse>
-        </div>
+          </BAccordionItem>
+        </BAccordion>
       </div>
     </BModal>
   </div>
 </template>
-
-<style scoped lang="scss">
-.card-collapse-wrapper {
-  border: $card-border-width solid $card-border-color;
-  border-radius: $card-border-radius;
-
-  .card {
-    &:first-child {
-      border-top: 0;
-      border-top-right-radius: $card-border-radius;
-      border-top-left-radius: $card-border-radius;
-    }
-    &:last-child {
-      border-bottom: 0;
-    }
-  }
-}
-</style>

--- a/app/src/views/update/SystemUpdate.vue
+++ b/app/src/views/update/SystemUpdate.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { secondsToHours } from 'date-fns/secondsToHours'
 
 import api from '@/api'
 import CardCollapse from '@/components/CardCollapse.vue'
@@ -13,14 +14,16 @@ const { t } = useI18n()
 const { tryToReconnect } = useSSE()
 const modalConfirm = useAutoModal()
 
-const { apps, system, importantYunohostUpgrade, pendingMigrations } = await api
-  .put<SystemUpdate>({ uri: 'update/all' })
-  .then(({ apps, system, important_yunohost_upgrade, pending_migrations }) => {
+const { apps, system, importantYunohostUpgrade, pendingMigrations, lastAptUpdate, lastAppsCatalogUpdate } = await api
+  .get<SystemUpdate>({ uri: 'update' })
+  .then(({ apps, system, important_yunohost_upgrade, pending_migrations, last_apt_update, last_apps_catalog_update }) => {
     return {
       apps: ref(apps.filter(app => app.upgrade.status != 'up_to_date')),
       system: ref(system),
       importantYunohostUpgrade: important_yunohost_upgrade,
       pendingMigrations: !!pending_migrations.length,
+      lastAptUpdate: secondsToHours(last_apt_update),
+      lastAppsCatalogUpdate: secondsToHours(last_apps_catalog_update),
     }
   })
 const preUpgrade = ref<
@@ -75,6 +78,11 @@ async function performAppsUpgrade(ids: string[]) {
   }
 }
 
+async function refreshUpdateCache() {
+  api.put<SystemUpdate>({ uri: 'update/all' })
+  .then(() => api.refetch())
+}
+
 async function performSystemUpgrade() {
   const confirmed = await modalConfirm(t('confirm_update_system'))
   if (!confirmed) return
@@ -103,10 +111,26 @@ async function performSystemUpgrade() {
       <span v-html="$t('important_yunohost_upgrade')" />
     </YAlert>
 
+    <!-- BUTTON TO REFRESH APT CACHE / CATALOG -->
+    <YAlert variant="info" class="mb-5">
+      <ButtonWithDetails
+        :label="t('update.refresh_cache')"
+        icon="refresh"
+        :details="t(
+          lastAptUpdate > 12 || lastAppsCatalogUpdate > 12 ? 'update.very_stale_cache' :
+          lastAptUpdate > 1 || lastAppsCatalogUpdate > 1 ? 'update.stale_cache' : 
+          'update.ok_cache',
+          {lastAptUpdate, lastAppsCatalogUpdate}
+          )"
+        :variant="info"
+        :onclick="refreshUpdateCache"
+      />
+    </YAlert>
+
     <!-- SYSTEM UPGRADE -->
-    <YCard :title="$t('system')" icon="server" no-body>
-      <BListGroup v-if="Object.keys(system).length" flush free>
-        <BListGroupItem
+    <YCard v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12" :title="$t('system')" icon="server" no-body>
+      <BAccordion v-if="Object.keys(system).length" flush free>
+        <BAccordionItem
           v-for="( packages, category ) in system"
           :key="category"
           header-tag="h3"
@@ -144,7 +168,7 @@ async function performSystemUpgrade() {
     </YCard>
 
     <!-- APPS UPGRADE -->
-    <YCard :title="$t('applications')" icon="cubes" no-body>
+    <YCard v-if="lastAptUpdate < 12 && lastAppsCatalogUpdate < 12" :title="$t('applications')" icon="cubes" no-body>
       <BListGroup v-if="apps.length" flush>
         <BListGroupItem
           v-for="{ name, id, upgrade } in apps"


### PR DESCRIPTION
Related to https://github.com/YunoHost/yunohost/pull/2115

### Screenshots (upgrade screen)

When apt / catalog is outdated (last refresh > 24 hours) only the refresh button is available to force admins to refresh the cache

<img width="1148" height="181" alt="2025-07-22-161030_1148x181_scrot" src="https://github.com/user-attachments/assets/ba41f618-7bd7-4de1-875c-bade047b4c27" />

System packages are now grouped by categories to be less like a huge wall of random technical names and a bit more sensible

<img width="1147" height="546" alt="2025-07-22-161335_1147x546_scrot" src="https://github.com/user-attachments/assets/04180c57-c9da-4c8e-86c3-d725f0a520f2" />

App upgrades now display specific messages when an upgrade could be available but some requirements arent met etc.

<img width="1138" height="519" alt="2025-07-22-162228_1138x519_scrot" src="https://github.com/user-attachments/assets/feeb7c22-a8a8-4531-95f7-52b74e38c221" />

### Screenshots (app info screen)

When requirements are not met

<img width="1141" height="380" alt="2025-07-22-161742_1141x380_scrot" src="https://github.com/user-attachments/assets/fb55ce8d-d3a2-48fc-bae7-55a344b65196" />

When app can be upgraded

<img width="1132" height="371" alt="2025-07-22-161810_1132x371_scrot" src="https://github.com/user-attachments/assets/8f422b58-4f61-4d19-8ad6-794b3e2a8523" />

When app is already up to date (but we display the force-upgrade button + tip about checking the package repo PRs for power user looking for a more recent version)

<img width="1134" height="427" alt="2025-07-22-161901_1134x427_scrot" src="https://github.com/user-attachments/assets/767bdee9-e26b-47de-a039-bb7b86e4a439" />

When a specific upgrade channel is used

<img width="1147" height="404" alt="2025-07-22-162401_1147x404_scrot" src="https://github.com/user-attachments/assets/9e10e5c6-0e9e-4e8d-b4ec-61765ecc747d" />

