### PR TITLE
WIP: Add quick info badges to home page (+ other places?)

### DIFF
--- a/app/components.d.ts
+++ b/app/components.d.ts
@@ -114,6 +114,7 @@ declare module 'vue' {
     TopBar: typeof import('./src/components/globals/TopBar.vue')['default']
     ViewSearch: typeof import('./src/components/globals/ViewSearch.vue')['default']
     YAlert: typeof import('./src/components/globals/YAlert.vue')['default']
+    YBadgeList: typeof import('./src/components/globals/YBadgeList.vue')['default']
     YBreadcrumb: typeof import('./src/components/globals/YBreadcrumb.vue')['default']
     YCard: typeof import('./src/components/globals/YCard.vue')['default']
     YIcon: typeof import('./src/components/globals/YIcon.vue')['default']

--- a/app/src/components/globals/YBadgeList.vue
+++ b/app/src/components/globals/YBadgeList.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+defineProps<{
+  badges: BadgeInfos[],
+}>()
+const slots = defineSlots<{
+  default?: any
+}>()
+</script>
+
+<template>
+    <ul v-if="badges" class="list-inline d-inline-block ms-3 my-0">
+      <li
+        v-for="badge in badges"
+        :key="badge.text"
+        class="list-inline-item me-1"
+      >
+        <BBadge :variant="badge.variant" pill>
+          <YIcon v-if="badge.icon" :iname="badge.icon" /> {{ badge.text }}
+        </BBadge>
+      </li>
+    </ul>
+</template>

--- a/app/src/components/globals/YListItem.vue
+++ b/app/src/components/globals/YListItem.vue
@@ -5,6 +5,7 @@ withDefaults(
     sublabel?: string
     description?: string
     imageSrc?: string
+    badges?: BadgesInfos[]
   }>(),
   {
     sublabel: undefined,
@@ -32,6 +33,7 @@ const slots = defineSlots<{
           <small v-if="sublabel" class="ms-1 text-secondary">
             {{ sublabel }}
           </small>
+          <YBadgeList v-if="badges" :badges="badges" />
         </h5>
         <p v-if="description || slots.default" class="m-0">
           <slot name="default">

--- a/app/src/types/commons.ts
+++ b/app/src/types/commons.ts
@@ -27,6 +27,11 @@ export type RouteFromTo = Record<'to' | 'from', RouteLocationNormalized>
 export type Translation = string | Record<string, string>
 export type StateVariant = 'success' | 'info' | 'warning' | 'danger'
 export type StateStatus = 'success' | 'info' | 'warning' | 'error'
+export type BadgeInfos = {
+  text: string
+  variant: string
+  icon?: string
+}
 
 // HELPERS
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import api from '@/api'
 const menu = [
   { routeName: 'user-list', icon: 'users', translation: 'users' },
   {
@@ -17,6 +18,43 @@ const menu = [
   },
   { routeName: 'backup', icon: 'archive', translation: 'backup' },
 ]
+
+const { apps_badges, upgrades_badges, diagnosis_badges } = await api
+  .get({ uri: 'dash', initial: true})
+  .then(({ apps, upgrades, diagnosis }) => {
+
+    let apps_badges: BadgeInfos[] = Array();
+    if (apps.notifications > 0) {
+        apps_badges.push({text: apps.notifications + ' notifications', variant: "info", icon: 'info-circle'})
+    }
+
+    let upgrades_badges: BadgeInfos[] = Array();
+    if (upgrades.pending_migrations > 0)
+    {
+        upgrades_badges.push({text: upgrades.pending_migrations + ' pending migrations', variant: "info", icon: "forward" })
+    }
+    if (upgrades.system_packages > 0)
+    {
+        upgrades_badges.push({text: upgrades.system_packages + ' system upgrades', variant: "info", icon: "server" })
+    }
+    if (upgrades.pending_migrations > 0)
+    {
+        upgrades_badges.push({text: upgrades.apps + ' app upgrades', variant: "info", icon: "cubes" })
+    }
+
+    let diagnosis_badges: BadgeInfos[] = Array();
+    if (diagnosis.warnings > 0)
+    {
+        diagnosis_badges.push({text: diagnosis.warnings + ' warnings', variant: "warning", icon: "exclamation-triangle" })
+    }
+    if (diagnosis.errors > 0)
+    {
+        diagnosis_badges.push({text: diagnosis.errors + ' issues', variant: "danger", icon: "times" })
+    }
+
+    return {apps_badges, upgrades_badges, diagnosis_badges}
+  })
+
 </script>
 
 <template>
@@ -29,6 +67,10 @@ const menu = [
       >
         <YIcon :iname="item.icon" class="lg ms-1" />
         <h4>{{ $t(item.translation) }}</h4>
+        <YBadgeList v-if="item.routeName == 'app-list'" :badges="apps_badges" />
+        <YBadgeList v-if="item.routeName == 'update'" :badges="upgrades_badges" />
+        <YBadgeList v-if="item.routeName == 'diagnosis'" :badges="diagnosis_badges" />
+
         <YIcon iname="chevron-right" class="lg fs-sm ms-auto" />
       </BListGroupItem>
     </BListGroup>

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -7,11 +7,29 @@ const apps = await api
   .get<AppList>({ uri: 'apps?full', initial: true })
   .then(({ apps }) => {
     return apps
-      .map(({ id, name, description, manifest, logo }) => {
+      .map(({ id, name, description, manifest, logo, upgrade, from_catalog}) => {
         const logoUrl = logo
           ? `./applogos/${logo}.png`
           : 'data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
-        return { id, name: manifest.name, label: name, description, logoUrl }
+        let badges: BadgesInfos = Array();
+        let notifications_count = Object.keys(manifest.notifications.POST_INSTALL || {}).length + Object.keys(manifest.notifications.POST_UPGRADE || {}).length
+        if (notifications_count > 0)
+        {
+           badges.push({text: notifications_count + ' notifications', variant: "info", icon: 'info-circle'})
+        }
+        if (upgrade.status == "upgradable")
+        {
+           badges.push({text: 'Upgrade available', variant: "info", icon: 'arrow-up'})
+        }
+        else if (upgrade.status == "url_required")
+        {
+           badges.push({text: 'Not in catalog', variant: "danger", icon: 'chain-broken'})
+        }
+        if ((id == 'helloworld__2') || (from_catalog && from_catalog.antifeatures && Array(from_catalog.antifeatures).includes("deprecated-software")))
+        {
+           badges.push({text: 'Deprecated', variant: "warning", icon: 'exclamation-triangle'})
+        }
+        return { id, label: name, description, logoUrl, badges }
       })
       .sort((prev, app) => {
         return prev.label > app.label ? 1 : -1
@@ -38,13 +56,14 @@ const [search, filteredApps] = useSearch(apps, (s, app) =>
 
     <BListGroup>
       <YListItem
-        v-for="{ id, description, label, logoUrl } in filteredApps"
+        v-for="{ id, description, label, logoUrl, badges } in filteredApps"
         :key="id"
         :to="{ name: 'app-info', params: { id } }"
         :label="label"
         :sublabel="id"
         :description="description"
         :image-src="logoUrl"
+        :badges="badges"
       />
     </BListGroup>
   </ViewSearch>


### PR DESCRIPTION
WIP

Related to https://github.com/YunoHost/yunohost/pull/2154

- [ ] Probably need to add proper typing to the `api.get( )` call ?
- [ ] Ideally this should be asynchronous to not delay the loading of the home page while the info is being fetched ? But not fluent enough in vue to know how to do that
- [ ] Fix i18n and responsiveness
- [ ] We should move the Tools > Migrations view to inside the Upgrade view
- [ ] Other ideas like:
    - [ ] On the app list page, add notification badges, upgrade badge ?, badge for apps flagged as deprecated or not in the catalog
    - [ ] On the Tools list, add badges for number of services that are down in front of the 'Services' key ?
    - [ ] On the domain page, add badge for DNS issues, self-signed certs or cert about to expire ?, or domain about to expire ? 

<img width="816" height="666" alt="2025-08-15-165924_816x666_scrot" src="https://github.com/user-attachments/assets/28338e29-5f42-4c78-b684-85397ecbb7aa" />
