### PR TITLE
Fix 'remove data dir' option in web admin has no effect #2610

### DIFF
--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -239,9 +239,10 @@ async function showModalUninstallButton() {
 }
 
 async function uninstall() {
-  const data = purge.value === true ? { purge: 1 } : {}
+  const options = purge.value === true ? { purge: 1 } : {}
+  const params = new URLSearchParams(options);
   api
-    .put({ uri: `apps/${props.id}/actions/_core.operations.uninstall`, data })
+    .delete({ uri: `apps/${props.id}?${params.toString()}` })
     .then(() => router.push({ name: 'app-list' }))
 }
 </script>


### PR DESCRIPTION
Fixes Yunohost/issues#2610
Fixes https://github.com/YunoHost-Apps/grist_ynh/issues/111

The fix consists in not using the `PUT /apps/{appId}/actions/_core.operations.uninstall` but rather `DELETE /apps/{appId}` route, which seems to recognize the `purge` query param and works as expected.

Note that I prefer not passing any body to the `DELETE` request. It seems to [be discouraged](https://lists.w3.org/Archives/Public/ietf-http-wg/2020JanMar/0123.html) (at least by the inventor of the REST API) and [implementations](https://dev.to/mdhabibur/shocking-truth-can-http-delete-requests-have-a-body-you-wont-believe-it-56bd) discard its content (Nginx for example? Needs to be tested). Anyway, I would suggest to stick with params if that works.