### PR TITLE
Pass delete params (Follow-up to #653)

### DIFF
--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -27,6 +27,10 @@ export type APIQuery = {
   initial?: boolean
 }
 
+export type APIQueryWithParams = APIQuery & {
+  params: Record<string, string>
+}
+
 export type APIErrorData = {
   error: string
   error_key?: string
@@ -226,8 +230,23 @@ export default {
    * @returns Promise that resolve the api response data or an error
    * @throws Throw an `APIError` or subclass depending on server response
    */
-  delete<T>(query: Omit<APIQuery, 'method'>): Promise<T> {
+  delete<T>(query: Omit<APIQuery, 'method' | 'data'>): Promise<T> {
     return this.fetch({ ...query, method: 'DELETE' })
+  },
+
+  /**
+   * Much like delete, but also accepts a params property that will be added
+   * to the passed URL.
+   *
+   * @param query - {@link APIQueryWithParams}
+   *
+   * @returns Promise that resolve the api response data or an error
+   * @throws Throw an `APIError` or subclass depending on server response
+   */
+  deleteWithParams<T>({params, ...query}: Omit<APIQueryWithParams, 'method' | 'data'>): Promise<T> {
+    const serializedParams = new URLSearchParams(params).toString();
+    const uri = query.uri.replace(/\?.*/, '') + "?" + serializedParams;
+    return this.delete({ ...query, uri })
   },
 
   refetch() {

--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -25,10 +25,7 @@ export type APIQuery = {
   ignoreError?: boolean
   isAction?: boolean
   initial?: boolean
-}
-
-export type APIQueryWithParams = APIQuery & {
-  params: Record<string, string>
+  params?: Record<string, string>
 }
 
 export type APIErrorData = {
@@ -99,6 +96,7 @@ export default {
     ignoreError = false,
     isAction = method !== 'GET',
     initial = false,
+    params = undefined
   }: APIQuery): Promise<T> {
     const cache = cachePath ? useCache<T>(method, cachePath) : undefined
     if (!cacheForce && method === 'GET' && cache?.content.value !== undefined) {
@@ -134,7 +132,14 @@ export default {
       }
     }
 
-    const response = await fetch('/yunohost/api/' + uri, options)
+    const fullUri = new URL('/yunohost/api/' + uri, location.href);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        fullUri.searchParams.append(key, value);
+      }
+    }
+
+    const response = await fetch(fullUri, options)
 
     if (!response.ok) {
       const errorData = await getResponseData<string | APIErrorData>(response)
@@ -232,21 +237,6 @@ export default {
    */
   delete<T>(query: Omit<APIQuery, 'method' | 'data'>): Promise<T> {
     return this.fetch({ ...query, method: 'DELETE' })
-  },
-
-  /**
-   * Much like delete, but also accepts a params property that will be added
-   * to the passed URL.
-   *
-   * @param query - {@link APIQueryWithParams}
-   *
-   * @returns Promise that resolve the api response data or an error
-   * @throws Throw an `APIError` or subclass depending on server response
-   */
-  deleteWithParams<T>({params, ...query}: Omit<APIQueryWithParams, 'method' | 'data'>): Promise<T> {
-    const serializedParams = new URLSearchParams(params).toString();
-    const uri = query.uri.replace(/\?.*/, '') + "?" + serializedParams;
-    return this.delete({ ...query, uri })
   },
 
   refetch() {

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -241,7 +241,7 @@ async function showModalUninstallButton() {
 async function uninstall() {
   const params = purge.value === true ? { purge: 1 } : {}
   api
-    .deleteWithParams({ uri: `apps/${props.id}`, params })
+    .delete({ uri: `apps/${props.id}`, params })
     .then(() => router.push({ name: 'app-list' }))
 }
 </script>

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -239,9 +239,10 @@ async function showModalUninstallButton() {
 }
 
 async function uninstall() {
-  const data = purge.value === true ? { purge: 1 } : {}
+  const options = purge.value === true ? { purge: 1 } : {}
+  const params = new URLSearchParams(options);
   api
-    .put({ uri: `apps/${props.id}/actions/_core.operations.uninstall`, data })
+    .delete({ uri: `apps/${props.id}?${params.toString()}` })
     .then(() => router.push({ name: 'app-list' }))
 }
 </script>

--- a/app/src/views/app/AppInfo.vue
+++ b/app/src/views/app/AppInfo.vue
@@ -239,10 +239,9 @@ async function showModalUninstallButton() {
 }
 
 async function uninstall() {
-  const options = purge.value === true ? { purge: 1 } : {}
-  const params = new URLSearchParams(options);
+  const params = purge.value === true ? { purge: 1 } : {}
   api
-    .delete({ uri: `apps/${props.id}?${params.toString()}` })
+    .deleteWithParams({ uri: `apps/${props.id}`, params })
     .then(() => router.push({ name: 'app-list' }))
 }
 </script>

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -77,7 +77,7 @@ async function deleteDomain() {
       : {}
 
   api
-    .deleteWithParams({
+    .delete({
       uri: `domains/${props.name}`,
       cachePath: `domains.${props.name}`,
       params,

--- a/app/src/views/domain/DomainInfo.vue
+++ b/app/src/views/domain/DomainInfo.vue
@@ -71,16 +71,16 @@ const isMainDynDomain = computed(() => {
 })
 
 async function deleteDomain() {
-  const data =
+  const params =
     isMainDynDomain.value && !unsubscribeDomainFromDyndns.value
       ? { ignore_dyndns: 1 }
       : {}
 
   api
-    .delete({
+    .deleteWithParams({
       uri: `domains/${props.name}`,
       cachePath: `domains.${props.name}`,
-      data,
+      params,
     })
     .then(() => {
       router.push({ name: 'domain-list' })

--- a/app/src/views/user/UserInfo.vue
+++ b/app/src/views/user/UserInfo.vue
@@ -18,12 +18,12 @@ const { user } = useUsersAndGroups(() => props.name)
 const purge = ref(false)
 
 function deleteUser() {
-  const data = purge.value ? { purge: '' } : {}
+  const params = purge.value ? { purge: '' } : {}
   api
-    .delete({
+    .deleteWithParams({
       uri: `users/${props.name}`,
       cachePath: `userDetails.${props.name}`,
-      data,
+      params,
     })
     .then(() => {
       router.push({ name: 'user-list' })

--- a/app/src/views/user/UserInfo.vue
+++ b/app/src/views/user/UserInfo.vue
@@ -20,7 +20,7 @@ const purge = ref(false)
 function deleteUser() {
   const params = purge.value ? { purge: '' } : {}
   api
-    .deleteWithParams({
+    .delete({
       uri: `users/${props.name}`,
       cachePath: `userDetails.${props.name}`,
       params,


### PR DESCRIPTION
This is a follow-up to #653.

I introduce a `params` property available for every method of the API, so passing query params to `delete()` is made easy.
Also I forbid passing data to the delete actions.

What I could check:
 - [x] App deletion and purging data works
 - [x] User deletion and purging data works
 - [ ] I could not check whether it works to ignore `ignore_dyndns`, I need help to test that properly.