### PR TITLE
Make app list sort case-insensitive

### DIFF
--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -6,6 +6,7 @@ import type { AppList } from '@/types/core/api'
 const apps = await api
   .get<AppList>({ uri: 'apps?full', initial: true })
   .then(({ apps }) => {
+    const collator = new Intl.Collator("en");
     return apps
       .map(({ id, name, description, manifest, logo }) => {
         const logoUrl = logo
@@ -13,7 +14,7 @@ const apps = await api
           : 'data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
         return { id, name: manifest.name, label: name, description, logoUrl }
       })
-      .sort((prev, app) => new Intl.Collator("en").compare)
+      .sort((prev, app) => collator.compare(prev.label, app.label))
   })
 
 const [search, filteredApps] = useSearch(apps, (s, app) =>

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -6,7 +6,7 @@ import type { AppList } from '@/types/core/api'
 const apps = await api
   .get<AppList>({ uri: 'apps?full', initial: true })
   .then(({ apps }) => {
-    const collator = new Intl.Collator("en");
+    const collator = new Intl.Collator('en')
     return apps
       .map(({ id, name, description, manifest, logo }) => {
         const logoUrl = logo

--- a/app/src/views/app/AppList.vue
+++ b/app/src/views/app/AppList.vue
@@ -13,9 +13,7 @@ const apps = await api
           : 'data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
         return { id, name: manifest.name, label: name, description, logoUrl }
       })
-      .sort((prev, app) => {
-        return prev.label > app.label ? 1 : -1
-      })
+      .sort((prev, app) => new Intl.Collator("en").compare)
   })
 
 const [search, filteredApps] = useSearch(apps, (s, app) =>


### PR DESCRIPTION
`[code-server, AppFlowy, Element]` would previously sort to `[AppFlowy, Element, code-server]`, now they sort to `[AppFlowy, code-server, Element]` which is a bit more expected. App `ĄĘ` will still come last, perhaps we should remove accents as well?

Actually I stand corrected

```js
console.log(["Bénévalibre", "ab", "Ąaaa", "Baba", "Bfbf", "ä", "b", "B"].sort(new Intl.Collator("en").compare));

>Array ["ä", "Ąaaa", "ab", "b", "B", "Baba", "Bénévalibre", "Bfbf"]
```
