### PR TITLE
Fix null ref_id crash in SSE: guard against null request id in histoyList filter

### DIFF
--- a/app/src/composables/useRequests.ts
+++ b/app/src/composables/useRequests.ts
@@ -52,7 +52,7 @@ export const useRequests = createGlobalState(() => {
   const locked = computed(() => currentRequest.value?.showModal)
   const historyList = computed<(APIRequest | APIRequestAction)[]>(() => {
     return requests.value
-      .filter((r) => (!!r.action && !r.id.startsWith('lock')) || !!r.err)
+      .filter((r) => (!!r.action && !r.id?.startsWith('lock')) || !!r.err)
       .reverse() as APIRequestAction[]
   })
   const currentRequest = computed(() => {
@@ -175,7 +175,7 @@ export const useRequests = createGlobalState(() => {
         // We can remove requests that are not actions or has no errors
         requests.value = requests.value.filter(
           (r) =>
-            r.showModal || (!!r.action && !r.id.startsWith('lock')) || !!r.err,
+            r.showModal || (!!r.action && !r.id?.startsWith('lock')) || !!r.err,
         )
       } else if (showError) {
         request.showModal = true


### PR DESCRIPTION
- https://github.com/YunoHost/yunohost/pull/2291 helps but it's not enough
- https://github.com/YunoHost/yunohost/pull/2290 should completely remove the error

but this PR is to just protect from null ref_id