### PR TITLE
[fix][a11y] Item are not read by screen reader in TagsSelectizeItem d…

### DIFF
--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -193,9 +193,9 @@ function onDropdownKeydown(e: KeyboardEvent) {
           <BDropdownItemButton
             v-for="(option, i) in availableOptions"
             :key="i"
-            @click="onAddTag(option, addTag)"
             role="menuitem"
             :aria-description="$t('Add')"
+            @click="onAddTag(option, addTag)"
           >
             {{ typeof option === 'string' ? option : option.text }}
           </BDropdownItemButton>

--- a/app/src/components/globals/formItems/TagsSelectizeItem.vue
+++ b/app/src/components/globals/formItems/TagsSelectizeItem.vue
@@ -194,6 +194,8 @@ function onDropdownKeydown(e: KeyboardEvent) {
             v-for="(option, i) in availableOptions"
             :key="i"
             @click="onAddTag(option, addTag)"
+            role="menuitem"
+            :aria-description="$t('Add')"
           >
             {{ typeof option === 'string' ? option : option.text }}
           </BDropdownItemButton>


### PR DESCRIPTION
…ropdown
## The problem
Orca (screen reader) read "Menu" instead of the text of the button.

## Solution
Use role menuitem instead and describe with a small add to explain what happen if activate the button

## Status
Tested